### PR TITLE
feat: 페이머니 충전

### DIFF
--- a/src/main/java/com/flab/coongyapay/account/mapper/BankAccountMapper.java
+++ b/src/main/java/com/flab/coongyapay/account/mapper/BankAccountMapper.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface BankAccountMapper {
@@ -16,6 +17,8 @@ public interface BankAccountMapper {
     boolean existsActiveByUserIdAndAccount(@Param("userId") Long userId, @Param("bankCode") String bankCode, @Param("accountNumber") String accountNumber);
 
     List<BankAccountDto> findActiveByUserId(@Param("userId") Long userId);
+
+    Optional<BankAccountDto> findActiveByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
     int softDelete(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/flab/coongyapay/account/mapper/BankAccountMapper.java
+++ b/src/main/java/com/flab/coongyapay/account/mapper/BankAccountMapper.java
@@ -20,5 +20,7 @@ public interface BankAccountMapper {
 
     Optional<BankAccountDto> findActiveByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
+    Optional<BankAccountDto> findById(@Param("id") Long id);
+
     int softDelete(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/flab/coongyapay/account/repository/BankAccountRepository.java
+++ b/src/main/java/com/flab/coongyapay/account/repository/BankAccountRepository.java
@@ -42,6 +42,10 @@ public class BankAccountRepository {
         return bankAccountMapper.findActiveByIdAndUserId(id, userId).map(bankAccountAssembler::toDomain);
     }
 
+    public Optional<BankAccount> findById(Long id) {
+        return bankAccountMapper.findById(id).map(bankAccountAssembler::toDomain);
+    }
+
     public int softDelete(Long id, Long userId) {
         return bankAccountMapper.softDelete(id, userId);
     }

--- a/src/main/java/com/flab/coongyapay/account/repository/BankAccountRepository.java
+++ b/src/main/java/com/flab/coongyapay/account/repository/BankAccountRepository.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Repository
@@ -35,6 +36,10 @@ public class BankAccountRepository {
         return bankAccountMapper.findActiveByUserId(userId).stream()
                 .map(bankAccountAssembler::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    public Optional<BankAccount> findActiveByIdAndUserId(Long id, Long userId) {
+        return bankAccountMapper.findActiveByIdAndUserId(id, userId).map(bankAccountAssembler::toDomain);
     }
 
     public int softDelete(Long id, Long userId) {

--- a/src/main/java/com/flab/coongyapay/bank/BankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankClient.java
@@ -36,4 +36,15 @@ public interface BankClient {
      * @return 은행이 인지하는 해당 거래의 상태
      */
     BankWithdrawalStatus getWithdrawalStatus(String externalIdempotencyKey);
+
+    /**
+     * 은행 계좌 환불 (보상, 외부·비가역). 출금과 대칭. 멱등키로 이중 환불을 방지한다.
+     * 명시적 실패는 BankWithdrawalRejectedException, 결과 불명은 BankSystemException.
+     */
+    void refund(String bankCode, String accountNumber, BigDecimal amount, String externalIdempotencyKey);
+
+    /**
+     * 환불 상태 조회(대사/재조회용).
+     */
+    BankRefundStatus getRefundStatus(String externalIdempotencyKey);
 }

--- a/src/main/java/com/flab/coongyapay/bank/BankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankClient.java
@@ -1,5 +1,7 @@
 package com.flab.coongyapay.bank;
 
+import java.math.BigDecimal;
+
 public interface BankClient {
 
     /**
@@ -16,4 +18,22 @@ public interface BankClient {
      * @param accountNumber
      */
     void validateWithdrawal(String bankCode, String accountNumber);
+
+    /**
+     * 은행 계좌 출금 (외부 API, 비가역). 멱등키(externalIdempotencyKey)로 재시도 시 이중 출금을 방지한다.
+     * 성공 시 정상 반환, 명시적 실패는 BusinessException(WITHDRAWAL_REJECTED 등),
+     * 결과 불명(timeout/5xx)은 BankSystemException 계열로 구분한다.
+     * @param bankCode 은행코드
+     * @param accountNumber 출금 계좌번호
+     * @param amount 출금액
+     * @param externalIdempotencyKey 은행 전송용 멱등키(거래 참조)
+     */
+    void withdraw(String bankCode, String accountNumber, BigDecimal amount, String externalIdempotencyKey);
+
+    /**
+     * 은행 거래 상태 조회 (대사/재조회용). 출금 멱등키(reference)로 실제 출금 여부를 재확인한다.
+     * @param externalIdempotencyKey 출금 시 사용한 은행 전송용 멱등키
+     * @return 은행이 인지하는 해당 거래의 상태
+     */
+    BankWithdrawalStatus getWithdrawalStatus(String externalIdempotencyKey);
 }

--- a/src/main/java/com/flab/coongyapay/bank/BankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankClient.java
@@ -7,8 +7,13 @@ public interface BankClient {
      * @param bankCode
      * @param accountNumber
      * @param accountHolderName
-     * @throws com.flab.coongyapay.common.exception.BusinessException
-     *  - BANK_SYSTEM_UNAVAILABLE: 은행 시스템 장애
      */
     void verify(String bankCode, String accountNumber, String accountHolderName);
+
+    /**
+     * 출금 가능 여부 검증
+     * @param bankCode
+     * @param accountNumber
+     */
+    void validateWithdrawal(String bankCode, String accountNumber);
 }

--- a/src/main/java/com/flab/coongyapay/bank/BankMaintenancePolicy.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankMaintenancePolicy.java
@@ -1,0 +1,22 @@
+package com.flab.coongyapay.bank;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalTime;
+
+@Component
+@RequiredArgsConstructor
+public class BankMaintenancePolicy {
+
+    private static final LocalTime MAINTENANCE_START_TIME = LocalTime.MIDNIGHT;
+    private static final LocalTime MAINTENANCE_END_TIME = LocalTime.of(0, 30);
+
+    private final Clock clock;
+
+    public boolean isMaintenanceTime() {
+        LocalTime now = LocalTime.now(clock);
+        return !now.isBefore(MAINTENANCE_START_TIME) && !now.isAfter(MAINTENANCE_END_TIME);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/bank/BankRefundStatus.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankRefundStatus.java
@@ -1,0 +1,10 @@
+package com.flab.coongyapay.bank;
+
+/**
+ * 은행이 인지하는 환불(보상) 거래 상태.
+ */
+public enum BankRefundStatus {
+    REFUNDED,      // 환불 확정됨
+    NOT_REFUNDED,  // 환불되지 않음(확정)
+    UNKNOWN        // 은행도 불명/조회 실패
+}

--- a/src/main/java/com/flab/coongyapay/bank/BankSystemException.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankSystemException.java
@@ -1,0 +1,11 @@
+package com.flab.coongyapay.bank;
+
+/**
+ * 은행 응답이 불명확한 경우(timeout/5xx). 출금 여부를 확신할 수 없으므로
+ * 워커는 UNKNOWN으로 전이하고 대사(재조회)로 확정한다.
+ */
+public class BankSystemException extends RuntimeException {
+    public BankSystemException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/bank/BankWithdrawalRejectedException.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankWithdrawalRejectedException.java
@@ -1,0 +1,11 @@
+package com.flab.coongyapay.bank;
+
+/**
+ * 은행이 출금을 명시적으로 거절(4xx)한 경우. 재시도해도 결과가 바뀌지 않으므로
+ * 워커는 재시도 없이 FAILED(WITHDRAWAL_REJECTED)로 전이한다.
+ */
+public class BankWithdrawalRejectedException extends RuntimeException {
+    public BankWithdrawalRejectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/bank/BankWithdrawalStatus.java
+++ b/src/main/java/com/flab/coongyapay/bank/BankWithdrawalStatus.java
@@ -1,0 +1,10 @@
+package com.flab.coongyapay.bank;
+
+/**
+ * 은행이 인지하는 출금 거래 상태 (대사/재조회 결과).
+ */
+public enum BankWithdrawalStatus {
+    WITHDRAWN,      // 출금 확정됨
+    NOT_WITHDRAWN,  // 출금되지 않음(확정)
+    UNKNOWN         // 은행도 불명/조회 실패
+}

--- a/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
@@ -6,12 +6,24 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+
+/**
+ * 실제 은행 연동을 대체하는 Stub. 기본 동작은 성공이며, 테스트는 시나리오를 주입해
+ * 거절(4xx)/불명(timeout·5xx)/대사 결과를 재현할 수 있다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class StubBankClient implements BankClient {
 
+    /** withdraw 시 재현할 결과 */
+    public enum WithdrawScenario { SUCCESS, REJECT, UNCLEAR }
+
     private final BankMaintenancePolicy bankMaintenancePolicy;
+
+    private volatile WithdrawScenario withdrawScenario = WithdrawScenario.SUCCESS;
+    private volatile BankWithdrawalStatus withdrawalStatus = BankWithdrawalStatus.WITHDRAWN;
 
     @Override
     public void verify(String bankCode, String accountNumber, String accountHolderName) {
@@ -24,5 +36,38 @@ public class StubBankClient implements BankClient {
             throw new BusinessException(ErrorCode.BANK_MAINTENANCE);
         }
         log.info("Validate withdrawal: bankCode={}, account number={}", bankCode, accountNumber);
+    }
+
+    @Override
+    public void withdraw(String bankCode, String accountNumber, BigDecimal amount, String externalIdempotencyKey) {
+        switch (withdrawScenario) {
+            case REJECT -> throw new BankWithdrawalRejectedException(
+                    "Withdrawal rejected by bank: key=" + externalIdempotencyKey);
+            case UNCLEAR -> throw new BankSystemException(
+                    "Withdrawal result unclear (timeout/5xx): key=" + externalIdempotencyKey);
+            default -> log.info("Withdraw success: bankCode={}, accountNumber={}, amount={}, key={}",
+                    bankCode, accountNumber, amount, externalIdempotencyKey);
+        }
+    }
+
+    @Override
+    public BankWithdrawalStatus getWithdrawalStatus(String externalIdempotencyKey) {
+        log.info("Get withdrawal status: key={}, status={}", externalIdempotencyKey, withdrawalStatus);
+        return withdrawalStatus;
+    }
+
+    // --- 테스트 시나리오 주입 ---
+
+    public void setWithdrawScenario(WithdrawScenario scenario) {
+        this.withdrawScenario = scenario;
+    }
+
+    public void setWithdrawalStatus(BankWithdrawalStatus status) {
+        this.withdrawalStatus = status;
+    }
+
+    public void reset() {
+        this.withdrawScenario = WithdrawScenario.SUCCESS;
+        this.withdrawalStatus = BankWithdrawalStatus.WITHDRAWN;
     }
 }

--- a/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
@@ -1,14 +1,28 @@
 package com.flab.coongyapay.bank;
 
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class StubBankClient implements BankClient {
+
+    private final BankMaintenancePolicy bankMaintenancePolicy;
 
     @Override
     public void verify(String bankCode, String accountNumber, String accountHolderName) {
         log.info("Bank account verified: bank code={}, account number={}, account holder name={}", bankCode, accountNumber, accountHolderName);
+    }
+
+    @Override
+    public void validateWithdrawal(String bankCode, String accountNumber) {
+        if (bankMaintenancePolicy.isMaintenanceTime()) {
+            throw new BusinessException(ErrorCode.BANK_MAINTENANCE);
+        }
+        log.info("Validate withdrawal: bankCode={}, account number={}", bankCode, accountNumber);
     }
 }

--- a/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
+++ b/src/main/java/com/flab/coongyapay/bank/StubBankClient.java
@@ -24,6 +24,8 @@ public class StubBankClient implements BankClient {
 
     private volatile WithdrawScenario withdrawScenario = WithdrawScenario.SUCCESS;
     private volatile BankWithdrawalStatus withdrawalStatus = BankWithdrawalStatus.WITHDRAWN;
+    private volatile WithdrawScenario refundScenario = WithdrawScenario.SUCCESS;
+    private volatile BankRefundStatus refundStatus = BankRefundStatus.REFUNDED;
 
     @Override
     public void verify(String bankCode, String accountNumber, String accountHolderName) {
@@ -56,6 +58,24 @@ public class StubBankClient implements BankClient {
         return withdrawalStatus;
     }
 
+    @Override
+    public void refund(String bankCode, String accountNumber, BigDecimal amount, String externalIdempotencyKey) {
+        switch (refundScenario) {
+            case REJECT -> throw new BankWithdrawalRejectedException(
+                    "Refund rejected by bank: key=" + externalIdempotencyKey);
+            case UNCLEAR -> throw new BankSystemException(
+                    "Refund result unclear (timeout/5xx): key=" + externalIdempotencyKey);
+            default -> log.info("Refund success: bankCode={}, accountNumber={}, amount={}, key={}",
+                    bankCode, accountNumber, amount, externalIdempotencyKey);
+        }
+    }
+
+    @Override
+    public BankRefundStatus getRefundStatus(String externalIdempotencyKey) {
+        log.info("Get refund status: key={}, status={}", externalIdempotencyKey, refundStatus);
+        return refundStatus;
+    }
+
     // --- 테스트 시나리오 주입 ---
 
     public void setWithdrawScenario(WithdrawScenario scenario) {
@@ -66,8 +86,18 @@ public class StubBankClient implements BankClient {
         this.withdrawalStatus = status;
     }
 
+    public void setRefundScenario(WithdrawScenario scenario) {
+        this.refundScenario = scenario;
+    }
+
+    public void setRefundStatus(BankRefundStatus status) {
+        this.refundStatus = status;
+    }
+
     public void reset() {
         this.withdrawScenario = WithdrawScenario.SUCCESS;
         this.withdrawalStatus = BankWithdrawalStatus.WITHDRAWN;
+        this.refundScenario = WithdrawScenario.SUCCESS;
+        this.refundStatus = BankRefundStatus.REFUNDED;
     }
 }

--- a/src/main/java/com/flab/coongyapay/charge/controller/ChargeController.java
+++ b/src/main/java/com/flab/coongyapay/charge/controller/ChargeController.java
@@ -1,0 +1,69 @@
+package com.flab.coongyapay.charge.controller;
+
+import com.flab.coongyapay.auth.userdetails.CustomUserDetails;
+import com.flab.coongyapay.charge.controller.dto.ChargeRequest;
+import com.flab.coongyapay.charge.controller.dto.ChargeResponse;
+import com.flab.coongyapay.charge.service.ChargeResult;
+import com.flab.coongyapay.charge.service.ChargeService;
+import com.flab.coongyapay.charge.service.ChargeTransaction;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class ChargeController {
+
+    private final ChargeService chargeService;
+    private final ChargeTransaction chargeTransaction;
+
+    @PostMapping("/api/v1/charges")
+    public ResponseEntity<?> charge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            @Valid @RequestBody ChargeRequest request) {
+
+        // 1. 멱등키 형식 검증
+        validateIdempotencyKey(idempotencyKey);
+
+        // 2. 충전 서비스 호출
+        ChargeResult result = chargeService.charge(userDetails.getUser().getId(), userDetails.getUser().getName(), idempotencyKey, request);
+
+        // 3. 서비스 호출 결과에 따른 응답 변환
+        if (result.isReplayed()) {
+            return ResponseEntity.status(result.getHttpStatus())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(result.getResponseBody());
+        }
+
+        ChargeResponse responseBody = new ChargeResponse(result.getChargeId(), TransactionStatus.CREATED.name());
+        return ResponseEntity.accepted()
+                .location(URI.create("/api/v1/charges/" + result.getChargeId()))
+                .body(responseBody);
+    }
+
+    private void validateIdempotencyKey(String idempotencyKey) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
+        }
+        try {
+            if (UUID.fromString(idempotencyKey).version() != 4) {
+                throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/controller/ChargeController.java
+++ b/src/main/java/com/flab/coongyapay/charge/controller/ChargeController.java
@@ -3,9 +3,9 @@ package com.flab.coongyapay.charge.controller;
 import com.flab.coongyapay.auth.userdetails.CustomUserDetails;
 import com.flab.coongyapay.charge.controller.dto.ChargeRequest;
 import com.flab.coongyapay.charge.controller.dto.ChargeResponse;
+import com.flab.coongyapay.charge.controller.dto.ChargeStatusResponse;
 import com.flab.coongyapay.charge.service.ChargeResult;
 import com.flab.coongyapay.charge.service.ChargeService;
-import com.flab.coongyapay.charge.service.ChargeTransaction;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import com.flab.coongyapay.transaction.enums.TransactionStatus;
@@ -14,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.UUID;
@@ -27,7 +24,6 @@ import java.util.UUID;
 public class ChargeController {
 
     private final ChargeService chargeService;
-    private final ChargeTransaction chargeTransaction;
 
     @PostMapping("/api/v1/charges")
     public ResponseEntity<?> charge(
@@ -54,7 +50,13 @@ public class ChargeController {
                 .body(responseBody);
     }
 
+    @GetMapping("/api/v1/charges/{chargeId}")
+    public ChargeStatusResponse getCharge(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long chargeId) {
+        return chargeService.getCharge(userDetails.getUser().getId(), chargeId);
+    }
+
     private void validateIdempotencyKey(String idempotencyKey) {
+
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
         }

--- a/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeRequest.java
+++ b/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeRequest.java
@@ -1,0 +1,28 @@
+package com.flab.coongyapay.charge.controller.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChargeRequest {
+
+    @NotNull(message = "FIELD_REQUIRED")
+    private Long bankAccountId;
+
+    @NotNull(message = "FIELD_REQUIRED")
+    @DecimalMin(value = "1", message = "INVALID_CHARGE_AMOUNT")
+    @DecimalMax(value = "2000000", message = "INVALID_CHARGE_AMOUNT")
+    private BigDecimal amount;
+
+    @Size(min = 1, max = 7, message = "INVALID_REMARK_LENGTH")
+    private String remark;
+
+    @NotBlank(message = "FIELD_REQUIRED")
+    @Pattern(regexp = "^\\d{6}$", message = "INVALID_TRANSFER_PIN_FORMAT")
+    private String transferPin;
+}

--- a/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeResponse.java
+++ b/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeResponse.java
@@ -1,0 +1,17 @@
+package com.flab.coongyapay.charge.controller.dto;
+
+import com.flab.coongyapay.transaction.domain.Transaction;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChargeResponse {
+
+    private final Long chargeId;
+    private final String status;
+
+    public static ChargeResponse from(Transaction transaction) {
+        return new ChargeResponse(transaction.getId(), transaction.getStatus().name());
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeStatusResponse.java
+++ b/src/main/java/com/flab/coongyapay/charge/controller/dto/ChargeStatusResponse.java
@@ -1,0 +1,23 @@
+package com.flab.coongyapay.charge.controller.dto;
+
+import com.flab.coongyapay.transaction.domain.Transaction;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ChargeStatusResponse {
+    private final Long chargeId;
+    private final String status;
+    private final BigDecimal amount;
+    private final String remark;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime completedAt;
+
+    public static ChargeStatusResponse from(Transaction transaction) {
+        return new ChargeStatusResponse(transaction.getId(), transaction.getStatus().name(), transaction.getAmount(), transaction.getRemark(), transaction.getCreatedAt(), transaction.getCompletedAt());
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/domain/Transaction.java
+++ b/src/main/java/com/flab/coongyapay/charge/domain/Transaction.java
@@ -1,0 +1,62 @@
+package com.flab.coongyapay.charge.domain;
+
+import com.flab.coongyapay.charge.enums.TransactionFailureReason;
+import com.flab.coongyapay.charge.enums.TransactionStatus;
+import com.flab.coongyapay.charge.enums.TransactionType;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+public class Transaction {
+
+    public static final BigDecimal MINIMUM_CHARGE_AMOUNT_LIMIT = BigDecimal.ONE;
+    public static final BigDecimal MAXIMUM_CHARGE_AMOUNT_LIMIT = BigDecimal.valueOf(2_000_000);
+    public static final int MAXIMUM_REMARK_LENGTH = 7;
+
+    private final Long id;
+    private final Long walletId;
+    private final TransactionType transactionType;
+    private final Long parentTransactionId;
+    private final BigDecimal amount;
+    private final TransactionStatus status;
+    private final String remark;
+    private final TransactionFailureReason failureReason;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime completedAt;
+
+    private Transaction(Long id, Long walletId, TransactionType transactionType, Long parentTransactionId, BigDecimal amount, TransactionStatus status, String remark, TransactionFailureReason failureReason, LocalDateTime createdAt, LocalDateTime completedAt) {
+        this.id = id;
+        this.walletId = walletId;
+        this.transactionType = transactionType;
+        this.parentTransactionId = parentTransactionId;
+        this.amount = amount;
+        this.status = status;
+        this.remark = remark;
+        this.failureReason = failureReason;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+    }
+
+    public static Transaction createCharge(Long walletId, BigDecimal amount, String remark) {
+        if (amount == null || amount.compareTo(MINIMUM_CHARGE_AMOUNT_LIMIT) < 0 || amount.compareTo(MAXIMUM_CHARGE_AMOUNT_LIMIT) > 0) {
+            throw new BusinessException(ErrorCode.INVALID_CHARGE_AMOUNT);
+        }
+
+        if (remark == null || remark.isBlank() || remark.length() > MAXIMUM_REMARK_LENGTH) {
+            throw new BusinessException(ErrorCode.INVALID_REMARK_LENGTH);
+        }
+
+        return new Transaction(null, walletId, TransactionType.CHARGE, null, amount, TransactionStatus.CREATED, remark, null, null, null);
+    }
+
+    public static Transaction from(Long id, Long walletId, TransactionType transactionType, Long parentTransactionId,
+                                   BigDecimal amount, TransactionStatus status, String remark,
+                                   TransactionFailureReason failureReason, LocalDateTime createdAt,
+                                   LocalDateTime completedAt) {
+        return new Transaction(id, walletId, transactionType, parentTransactionId, amount, status, remark, failureReason, createdAt, completedAt);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/enums/EntryType.java
+++ b/src/main/java/com/flab/coongyapay/charge/enums/EntryType.java
@@ -1,0 +1,6 @@
+package com.flab.coongyapay.charge.enums;
+
+public enum EntryType {
+    CREDIT,
+    DEBIT
+}

--- a/src/main/java/com/flab/coongyapay/charge/enums/TransactionFailureReason.java
+++ b/src/main/java/com/flab/coongyapay/charge/enums/TransactionFailureReason.java
@@ -1,0 +1,8 @@
+package com.flab.coongyapay.charge.enums;
+
+public enum TransactionFailureReason {
+    WITHDRAWAL_REJECTED,
+    WITHDRAWAL_NOT_COMPLETED,
+    BANK_MAINTENANCE,
+    REFUNDED
+}

--- a/src/main/java/com/flab/coongyapay/charge/enums/TransactionStatus.java
+++ b/src/main/java/com/flab/coongyapay/charge/enums/TransactionStatus.java
@@ -1,0 +1,15 @@
+package com.flab.coongyapay.charge.enums;
+
+public enum TransactionStatus {
+    CREATED,
+    WITHDRAWING,
+    WITHDRAWN,
+    DEPOSITING,
+    COMPLETED,
+    FAILED,
+    EXPIRED,
+    UNKNOWN,
+    COMPENSATING,
+    REFUNDING,
+    NEEDS_REVIEW
+}

--- a/src/main/java/com/flab/coongyapay/charge/enums/TransactionType.java
+++ b/src/main/java/com/flab/coongyapay/charge/enums/TransactionType.java
@@ -1,0 +1,8 @@
+package com.flab.coongyapay.charge.enums;
+
+public enum TransactionType {
+    CHARGE,
+    WITHDRAW,
+    TRANSFER,
+    COMPENSATION
+}

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeCreditService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeCreditService.java
@@ -1,0 +1,72 @@
+package com.flab.coongyapay.charge.service;
+
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.domain.TransactionEntry;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.repository.TransactionEntryRepository;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+/**
+ * 지갑 크레딧(로컬 원장 기록). 은행 출금이 확정된(WITHDRAWN/DEPOSITING) 거래를 지갑에 반영한다.
+ * wallet FOR UPDATE → 한도 재검증 → 원장 CREDIT append → balance/version UPDATE → COMPLETED 를
+ * 하나의 트랜잭션에서 원자적으로 수행한다.
+ *
+ * 멱등성: (transaction_id, entry_type) UNIQUE + check-then-insert. 이미 CREDIT이 있으면
+ * 이중 입금하지 않고 성공으로 간주한다(재시도/중복 처리 안전).
+ */
+@Service
+@RequiredArgsConstructor
+public class ChargeCreditService {
+
+    private final WalletRepository walletRepository;
+    private final TransactionRepository transactionRepository;
+    private final TransactionEntryRepository transactionEntryRepository;
+    private final Clock clock;
+
+    @Transactional
+    public void credit(Long transactionId) {
+        Transaction transaction = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+        // 이미 크레딧된 경우 멱등 성공: 상태만 COMPLETED로 마감 시도
+        if (transactionEntryRepository.existsCredit(transactionId)) {
+            transactionRepository.updateStatus(transactionId, TransactionStatus.DEPOSITING,
+                    TransactionStatus.COMPLETED, null, LocalDateTime.now(clock));
+            return;
+        }
+
+        // 모든 잔액 기록자는 wallet 행을 먼저 락한다.
+        Wallet wallet = walletRepository.findByIdForUpdate(transaction.getWalletId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+        // 크레딧 시점 한도 재검증 (락 보유). 초과 시 보상 대상(3D). 3A에서는 예외로 표면화.
+        if (!wallet.isChargeableWithin(BigDecimal.ZERO, transaction.getAmount())) {
+            throw new BusinessException(ErrorCode.WALLET_BALANCE_LIMIT_EXCEEDED);
+        }
+
+        BigDecimal balanceAfter = wallet.getBalance().add(transaction.getAmount());
+        long nextSequence = wallet.getVersion() + 1;
+
+        // 1. 원장 CREDIT append (wallet_sequence = version + 1)
+        transactionEntryRepository.save(
+                TransactionEntry.credit(transactionId, wallet.getId(), transaction.getAmount(), balanceAfter, nextSequence));
+
+        // 2. 지갑 잔액/버전 갱신 (version = 최신 wallet_sequence)
+        walletRepository.updateBalanceAndVersion(wallet.getId(), balanceAfter, nextSequence);
+
+        // 3. 거래 완료 (DEPOSITING → COMPLETED)
+        transactionRepository.updateStatus(transactionId, TransactionStatus.DEPOSITING,
+                TransactionStatus.COMPLETED, null, LocalDateTime.now(clock));
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeCreditService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeCreditService.java
@@ -35,14 +35,14 @@ public class ChargeCreditService {
     private final Clock clock;
 
     @Transactional
-    public void credit(Long transactionId) {
+    public void credit(Long transactionId, long leaseToken) {
         Transaction transaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-        // 이미 크레딧된 경우 멱등 성공: 상태만 COMPLETED로 마감 시도
+        // 이미 크레딧된 경우 멱등 성공: 상태만 COMPLETED로 마감 시도(펜싱)
         if (transactionEntryRepository.existsCredit(transactionId)) {
-            transactionRepository.updateStatus(transactionId, TransactionStatus.DEPOSITING,
-                    TransactionStatus.COMPLETED, null, LocalDateTime.now(clock));
+            transactionRepository.updateStatusFenced(transactionId, TransactionStatus.DEPOSITING,
+                    TransactionStatus.COMPLETED, null, LocalDateTime.now(clock), leaseToken);
             return;
         }
 
@@ -65,8 +65,8 @@ public class ChargeCreditService {
         // 2. 지갑 잔액/버전 갱신 (version = 최신 wallet_sequence)
         walletRepository.updateBalanceAndVersion(wallet.getId(), balanceAfter, nextSequence);
 
-        // 3. 거래 완료 (DEPOSITING → COMPLETED)
-        transactionRepository.updateStatus(transactionId, TransactionStatus.DEPOSITING,
-                TransactionStatus.COMPLETED, null, LocalDateTime.now(clock));
+        // 3. 거래 완료 (DEPOSITING → COMPLETED, 펜싱)
+        transactionRepository.updateStatusFenced(transactionId, TransactionStatus.DEPOSITING,
+                TransactionStatus.COMPLETED, null, LocalDateTime.now(clock), leaseToken);
     }
 }

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeResult.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeResult.java
@@ -1,0 +1,22 @@
+package com.flab.coongyapay.charge.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChargeResult {
+
+    private final Long chargeId;
+    private final boolean replayed;
+    private final Integer httpStatus;
+    private final String responseBody;
+
+    public static ChargeResult fresh(Long chargeId) {
+        return new ChargeResult(chargeId, false, null, null);
+    }
+
+    public static ChargeResult replay(int httpStatus, String responseBody) {
+        return new ChargeResult(null, true, httpStatus, responseBody);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
@@ -1,0 +1,121 @@
+package com.flab.coongyapay.charge.service;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.bank.BankClient;
+import com.flab.coongyapay.bank.BankMaintenancePolicy;
+import com.flab.coongyapay.charge.controller.dto.ChargeRequest;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.common.exception.ErrorResponse;
+import com.flab.coongyapay.common.util.RequestHashUtil;
+import com.flab.coongyapay.idempotency.service.ClaimResult;
+import com.flab.coongyapay.idempotency.service.IdempotencyService;
+import com.flab.coongyapay.user.service.UserTransferPinVerifier;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class ChargeService {
+    private static final String DELIMITER = "|";
+    private static final String ENDPOINT = "POST /api/v1/charges";
+    private static final int MAX_REMARK_LENGTH = 7;
+
+    private final IdempotencyService idempotencyService;
+    private final BankMaintenancePolicy bankMaintenancePolicy;
+    private final BankAccountRepository bankAccountRepository;
+    private final WalletRepository walletRepository;
+    private final UserTransferPinVerifier userTransferPinVerifier;
+    private final BankClient bankClient;
+    private final ChargeTransaction chargeTransaction;
+    private final ObjectMapper objectMapper;
+
+    public ChargeResult charge(Long userId, String userName, String idempotencyKey, ChargeRequest request) {
+        // 1. 멱등키 선점
+        String requestHash = RequestHashUtil.sha256Hex(canonicalize(request));
+        ClaimResult claimed = idempotencyService.claim(userId, ENDPOINT, idempotencyKey, requestHash);
+        if (claimed.isReplayed()) {
+            return ChargeResult.replay(claimed.getResponseHttpStatus(), claimed.getCachedResponseBody());
+        }
+
+        // 2. 사전 검증
+        BankAccount bankAccount;
+        try {
+            // 2.1. 은행 점검 시간 검증
+            if (bankMaintenancePolicy.isMaintenanceTime()) {
+                throw new BusinessException(ErrorCode.BANK_MAINTENANCE);
+            }
+
+            // 2.2. 계좌 소유 및 활성 여부 검증
+            bankAccount = bankAccountRepository.findActiveByIdAndUserId(request.getBankAccountId(), userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+            // 2.3. 지갑 잔액 한도 검증
+            Wallet wallet = walletRepository.findByUserId(userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+            if (!wallet.isChargeableWithin(BigDecimal.ZERO, request.getAmount())) {
+                throw new BusinessException(ErrorCode.WALLET_BALANCE_LIMIT_EXCEEDED);
+            }
+
+            // 2.4. 송금비밀번호 검증
+            userTransferPinVerifier.verify(userId, request.getTransferPin());
+        } catch (BusinessException e) {
+            // 사전 검증 실패 시 멱등키 release
+            idempotencyService.release(userId, ENDPOINT, idempotencyKey);
+            throw e;
+        }
+
+        // 3. 은행 출금 사전 검증
+        try {
+            bankClient.validateWithdrawal(bankAccount.getBankCode(), bankAccount.getAccountNumber());
+        } catch (BusinessException e) {
+            cacheFailure(userId, idempotencyKey, e);
+            throw e;
+        }
+
+        // 4. 충전 접수 커밋
+        try {
+            String remark = resolveRemark(request.getRemark(), userName);
+            return chargeTransaction.commitReceipt(userId, ENDPOINT, idempotencyKey, request.getAmount(), remark);
+        } catch (BusinessException e) {
+            cacheFailure(userId, idempotencyKey, e);
+            throw e;
+        }
+    }
+
+    private String canonicalize(ChargeRequest request) {
+        return request.getBankAccountId() + DELIMITER
+                + request.getAmount().stripTrailingZeros().toPlainString() + DELIMITER
+                + (request.getRemark() == null ? "" : request.getRemark());
+    }
+
+    private void cacheFailure(Long userId, String idempotencyKey, BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        String body = serialize(ErrorResponse.of(errorCode));
+        idempotencyService.complete(userId, ENDPOINT, idempotencyKey, errorCode.getHttpStatus().value(), body);
+    }
+
+    private String serialize(ErrorResponse response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JacksonException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String resolveRemark(String remark, String userName) {
+        if (remark == null || remark.isBlank()) {
+            return userName.substring(0, Math.min(userName.length(), MAX_REMARK_LENGTH));
+        }
+
+        return remark;
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
@@ -6,6 +6,7 @@ import com.flab.coongyapay.bank.BankClient;
 import com.flab.coongyapay.bank.BankMaintenancePolicy;
 import com.flab.coongyapay.charge.controller.dto.ChargeRequest;
 import com.flab.coongyapay.charge.controller.dto.ChargeStatusResponse;
+import com.flab.coongyapay.charge.worker.ChargeDispatcher;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import com.flab.coongyapay.common.exception.ErrorResponse;
@@ -41,6 +42,7 @@ public class ChargeService {
     private final ChargeTransaction chargeTransaction;
     private final ObjectMapper objectMapper;
     private final TransactionRepository transactionRepository;
+    private final ChargeDispatcher chargeDispatcher;
 
     public ChargeResult charge(Long userId, String userName, String idempotencyKey, ChargeRequest request) {
         // 1. 멱등키 선점
@@ -87,13 +89,18 @@ public class ChargeService {
         }
 
         // 4. 충전 접수 커밋
+        ChargeResult result;
         try {
             String remark = resolveRemark(request.getRemark(), userName);
-            return chargeTransaction.commitReceipt(userId, ENDPOINT, idempotencyKey, bankAccount.getId(), request.getAmount(), remark);
+            result = chargeTransaction.commitReceipt(userId, ENDPOINT, idempotencyKey, bankAccount.getId(), request.getAmount(), remark);
         } catch (BusinessException e) {
             cacheFailure(userId, idempotencyKey, e);
             throw e;
         }
+
+        // 5. 커밋 후 fast-path 트리거(best-effort). 실패해도 스케줄 워커가 처리.
+        chargeDispatcher.dispatchAsync();
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
@@ -5,17 +5,21 @@ import com.flab.coongyapay.account.repository.BankAccountRepository;
 import com.flab.coongyapay.bank.BankClient;
 import com.flab.coongyapay.bank.BankMaintenancePolicy;
 import com.flab.coongyapay.charge.controller.dto.ChargeRequest;
+import com.flab.coongyapay.charge.controller.dto.ChargeStatusResponse;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import com.flab.coongyapay.common.exception.ErrorResponse;
 import com.flab.coongyapay.common.util.RequestHashUtil;
 import com.flab.coongyapay.idempotency.service.ClaimResult;
 import com.flab.coongyapay.idempotency.service.IdempotencyService;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
 import com.flab.coongyapay.user.service.UserTransferPinVerifier;
 import com.flab.coongyapay.wallet.domain.Wallet;
 import com.flab.coongyapay.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -36,6 +40,7 @@ public class ChargeService {
     private final BankClient bankClient;
     private final ChargeTransaction chargeTransaction;
     private final ObjectMapper objectMapper;
+    private final TransactionRepository transactionRepository;
 
     public ChargeResult charge(Long userId, String userName, String idempotencyKey, ChargeRequest request) {
         // 1. 멱등키 선점
@@ -89,6 +94,14 @@ public class ChargeService {
             cacheFailure(userId, idempotencyKey, e);
             throw e;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public ChargeStatusResponse getCharge(Long userId, Long chargeId) {
+        Transaction chargeTransaction = transactionRepository.findChargeByIdAndUserId(chargeId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRANSACTION_NOT_FOUND));
+
+        return ChargeStatusResponse.from(chargeTransaction);
     }
 
     private String canonicalize(ChargeRequest request) {

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeService.java
@@ -89,7 +89,7 @@ public class ChargeService {
         // 4. 충전 접수 커밋
         try {
             String remark = resolveRemark(request.getRemark(), userName);
-            return chargeTransaction.commitReceipt(userId, ENDPOINT, idempotencyKey, request.getAmount(), remark);
+            return chargeTransaction.commitReceipt(userId, ENDPOINT, idempotencyKey, bankAccount.getId(), request.getAmount(), remark);
         } catch (BusinessException e) {
             cacheFailure(userId, idempotencyKey, e);
             throw e;

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeTransaction.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeTransaction.java
@@ -28,7 +28,7 @@ public class ChargeTransaction {
     private final ObjectMapper objectMapper;
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public ChargeResult commitReceipt(Long userId, String endpoint, String idempotencyKey, BigDecimal amount, String remark) {
+    public ChargeResult commitReceipt(Long userId, String endpoint, String idempotencyKey, Long accountId, BigDecimal amount, String remark) {
         // 1. wallet 단위 비관적 락
         Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
@@ -40,8 +40,8 @@ public class ChargeTransaction {
             throw new BusinessException(ErrorCode.WALLET_BALANCE_LIMIT_EXCEEDED);
         }
 
-        // 3. 거래 CREATED 생성
-        Transaction savedTransaction = transactionRepository.save(Transaction.createCharge(walletId, amount, remark));
+        // 3. 거래 CREATED 생성 (출금 대상 계좌 account_id 연결 → 비동기 워커가 출금에 사용)
+        Transaction savedTransaction = transactionRepository.save(Transaction.createCharge(walletId, accountId, amount, remark));
 
         // 4. 멱등키 COMPLETED + 202 Accepted 응답 캐시
         String body = serialize(ChargeResponse.from(savedTransaction));

--- a/src/main/java/com/flab/coongyapay/charge/service/ChargeTransaction.java
+++ b/src/main/java/com/flab/coongyapay/charge/service/ChargeTransaction.java
@@ -1,0 +1,60 @@
+package com.flab.coongyapay.charge.service;
+
+import com.flab.coongyapay.charge.controller.dto.ChargeResponse;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.idempotency.service.IdempotencyService;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class ChargeTransaction {
+
+    private final WalletRepository walletRepository;
+    private final TransactionRepository transactionRepository;
+    private final IdempotencyService idempotencyService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public ChargeResult commitReceipt(Long userId, String endpoint, String idempotencyKey, BigDecimal amount, String remark) {
+        // 1. wallet 단위 비관적 락
+        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+        Long walletId = wallet.getId();
+
+        // 2. 처리 중인 충전 거래 포함하여 한도 재검증
+        BigDecimal inFlight = transactionRepository.sumInFlightChargeByWalletId(walletId);
+        if (!wallet.isChargeableWithin(inFlight, amount)) {
+            throw new BusinessException(ErrorCode.WALLET_BALANCE_LIMIT_EXCEEDED);
+        }
+
+        // 3. 거래 CREATED 생성
+        Transaction savedTransaction = transactionRepository.save(Transaction.createCharge(walletId, amount, remark));
+
+        // 4. 멱등키 COMPLETED + 202 Accepted 응답 캐시
+        String body = serialize(ChargeResponse.from(savedTransaction));
+        idempotencyService.complete(userId, endpoint, idempotencyKey, HttpStatus.ACCEPTED.value(), body);
+
+        return ChargeResult.fresh(savedTransaction.getId());
+    }
+
+    private String serialize(ChargeResponse response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JacksonException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeClaimService.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeClaimService.java
@@ -1,0 +1,41 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * "짧게 선점": FOR UPDATE SKIP LOCKED로 진행 가능한 거래를 골라 즉시 lease를 세팅(짧은 트랜잭션).
+ * 트랜잭션 커밋으로 행 락은 풀리지만 lease가 유효한 동안 다른 워커의 재선점을 막는다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ChargeClaimService {
+
+    // 3B 해피 경로에서 전진 처리 대상. (UNKNOWN/COMPENSATING 처리는 3C/3D에서 확장)
+    private static final List<TransactionStatus> CLAIMABLE_STATUSES = List.of(
+            TransactionStatus.CREATED,
+            TransactionStatus.WITHDRAWING,
+            TransactionStatus.WITHDRAWN,
+            TransactionStatus.DEPOSITING,
+            TransactionStatus.UNKNOWN);
+
+    private final TransactionRepository transactionRepository;
+
+    @Transactional
+    public List<ClaimedTransaction> claimBatch(int limit, int leaseSeconds) {
+        List<Long> ids = transactionRepository.selectClaimableIds(TransactionType.CHARGE, CLAIMABLE_STATUSES, limit);
+        List<ClaimedTransaction> claimed = new ArrayList<>(ids.size());
+        for (Long id : ids) {
+            transactionRepository.acquireLease(id, leaseSeconds);
+            claimed.add(new ClaimedTransaction(id, transactionRepository.findLeaseToken(id)));
+        }
+        return claimed;
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeDispatcher.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeDispatcher.java
@@ -1,0 +1,47 @@
+package com.flab.coongyapay.charge.worker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 선점→처리 한 사이클을 실행하는 공용 디스패처.
+ * - 내구 경로: {@link ChargeWorker}가 @Scheduled로 runOnce() 호출
+ * - fast-path: 커밋 직후 {@link #dispatchAsync()}로 즉시 처리(@Async, best-effort)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChargeDispatcher {
+
+    private static final int BATCH_SIZE = 50;
+    private static final int LEASE_SECONDS = 30;
+
+    private final ChargeClaimService chargeClaimService;
+    private final ChargeProcessor chargeProcessor;
+
+    public void runOnce() {
+        List<ClaimedTransaction> claimed = chargeClaimService.claimBatch(BATCH_SIZE, LEASE_SECONDS);
+        for (ClaimedTransaction transaction : claimed) {
+            try {
+                chargeProcessor.process(transaction.id(), transaction.leaseToken());
+            } catch (Exception e) {
+                // 예외 시 lease 만료 후 재선점되어 재처리(내구성). 실패 유형별 전이는 3C에서 정교화.
+                log.warn("Charge processing failed: transactionId={}", transaction.id(), e);
+            }
+        }
+    }
+
+    /** 커밋 직후 호출되는 fast-path. 실패해도 스케줄 워커가 결국 처리하므로 best-effort. */
+    @Async
+    public void dispatchAsync() {
+        try {
+            runOnce();
+        } catch (Exception e) {
+            log.warn("Async charge dispatch failed", e);
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
@@ -17,12 +17,14 @@ import com.flab.coongyapay.transaction.mapper.dto.RetryStateDto;
 import com.flab.coongyapay.transaction.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 /**
  * CHARGE 거래 상태머신을 전진시키는 워커.
@@ -59,6 +61,7 @@ public class ChargeProcessor {
             case WITHDRAWING -> executeWithdrawal(transaction, leaseToken);
             case WITHDRAWN, DEPOSITING -> credit(transaction, leaseToken);
             case UNKNOWN -> reconcileWithdrawal(transaction, leaseToken);
+            case COMPENSATING -> checkCompensationCompletion(transaction, leaseToken);
             default -> { /* terminal 등: no-op */ }
         }
     }
@@ -115,16 +118,48 @@ public class ChargeProcessor {
             // 락 타임아웃/데드락 등 일시 실패 → 백오프 재시도
             RetryStateDto retry = transactionRepository.findRetryState(id);
             if (retry.getRetryCount() >= retry.getMaxRetries()) {
-                // 재시도 소진 → 후진 복구(보상) 개시. 보상 거래 생성/처리는 3D.
-                transactionRepository.updateStatusFenced(id, TransactionStatus.DEPOSITING,
-                        TransactionStatus.COMPENSATING, null, null, leaseToken);
+                initiateCompensation(transaction, leaseToken); // 재시도 소진 → 후진 복구
             } else {
                 transactionRepository.scheduleRetry(id, backoffSeconds(retry.getRetryCount()), leaseToken);
             }
         } catch (BusinessException e) {
-            // 한도 초과 등 영구 실패 → 즉시 보상 개시(재시도 무의미). 보상 처리는 3D.
-            transactionRepository.updateStatusFenced(id, TransactionStatus.DEPOSITING,
-                    TransactionStatus.COMPENSATING, null, null, leaseToken);
+            // 한도 초과 등 영구 실패 → 즉시 보상 개시(재시도 무의미)
+            initiateCompensation(transaction, leaseToken);
+        }
+    }
+
+    // 후진 복구 개시: DEPOSITING → COMPENSATING + 보상 거래 생성(UNIQUE(parent)로 이중 보상 차단)
+    private void initiateCompensation(Transaction charge, long leaseToken) {
+        boolean moved = transactionRepository.updateStatusFenced(charge.getId(), TransactionStatus.DEPOSITING,
+                TransactionStatus.COMPENSATING, null, null, leaseToken);
+        if (!moved) {
+            return;
+        }
+        createCompensationChild(charge);
+    }
+
+    private void createCompensationChild(Transaction charge) {
+        if (transactionRepository.findByParentTransactionId(charge.getId()).isPresent()) {
+            return;
+        }
+        try {
+            transactionRepository.save(com.flab.coongyapay.transaction.domain.Transaction.createCompensation(
+                    charge.getWalletId(), charge.getAccountId(), charge.getAmount(), charge.getId()));
+        } catch (DuplicateKeyException ignore) {
+            // 동시 생성 경합: UNIQUE(parent_transaction_id)가 하나만 허용
+        }
+    }
+
+    // COMPENSATING 안전망: 자식 보상이 없으면 생성, COMPLETED면 부모를 FAILED(REFUNDED)로 마감
+    private void checkCompensationCompletion(Transaction charge, long leaseToken) {
+        Optional<Transaction> child = transactionRepository.findByParentTransactionId(charge.getId());
+        if (child.isEmpty()) {
+            createCompensationChild(charge);
+            return;
+        }
+        if (child.get().getStatus() == TransactionStatus.COMPLETED) {
+            transactionRepository.updateStatusFenced(charge.getId(), TransactionStatus.COMPENSATING,
+                    TransactionStatus.FAILED, TransactionFailureReason.REFUNDED, now(), leaseToken);
         }
     }
 

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
@@ -1,0 +1,71 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.bank.BankClient;
+import com.flab.coongyapay.charge.service.ChargeCreditService;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * CHARGE 거래 상태머신을 전진시키는 워커(3A 해피패스).
+ * CREATED → WITHDRAWING → (은행 출금) → WITHDRAWN → DEPOSITING → COMPLETED.
+ *
+ * 핵심 원칙: 은행 출금(withdraw)은 트랜잭션/락 밖에서, 크레딧(원장 기록)은 wallet FOR UPDATE 트랜잭션 안에서.
+ * 상태 전이는 CAS(updateStatus)로 처리해 중복 처리를 방지한다.
+ * (재시도/UNKNOWN/보상/펜싱은 3B~3D에서 확장)
+ */
+@Component
+@RequiredArgsConstructor
+public class ChargeProcessor {
+
+    private final TransactionRepository transactionRepository;
+    private final BankAccountRepository bankAccountRepository;
+    private final BankClient bankClient;
+    private final ChargeCreditService chargeCreditService;
+
+    public void process(Long transactionId) {
+        Transaction transaction = transactionRepository.findById(transactionId).orElse(null);
+        if (transaction == null || !transaction.isCharge()) {
+            return;
+        }
+
+        TransactionStatus status = transaction.getStatus();
+
+        // 1. 출금 단계 (CREATED 진입): write-ahead 의도 후 외부 출금 → WITHDRAWN
+        if (status == TransactionStatus.CREATED) {
+            boolean claimed = transactionRepository.updateStatus(transactionId,
+                    TransactionStatus.CREATED, TransactionStatus.WITHDRAWING, null, null);
+            if (!claimed) {
+                return; // 다른 워커가 선점
+            }
+            withdraw(transaction);
+            transactionRepository.updateStatus(transactionId,
+                    TransactionStatus.WITHDRAWING, TransactionStatus.WITHDRAWN, null, null);
+            status = TransactionStatus.WITHDRAWN;
+        }
+
+        // 2. 크레딧 단계 (WITHDRAWN/DEPOSITING): 지갑 반영 → COMPLETED
+        if (status == TransactionStatus.WITHDRAWN || status == TransactionStatus.DEPOSITING) {
+            transactionRepository.updateStatus(transactionId,
+                    TransactionStatus.WITHDRAWN, TransactionStatus.DEPOSITING, null, null);
+            chargeCreditService.credit(transactionId);
+        }
+    }
+
+    private void withdraw(Transaction transaction) {
+        BankAccount account = bankAccountRepository.findById(transaction.getAccountId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+        bankClient.withdraw(account.getBankCode(), account.getAccountNumber(),
+                transaction.getAmount(), externalIdempotencyKey(transaction.getId()));
+    }
+
+    private String externalIdempotencyKey(Long transactionId) {
+        return "charge-" + transactionId;
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
@@ -3,31 +3,50 @@ package com.flab.coongyapay.charge.worker;
 import com.flab.coongyapay.account.domain.BankAccount;
 import com.flab.coongyapay.account.repository.BankAccountRepository;
 import com.flab.coongyapay.bank.BankClient;
+import com.flab.coongyapay.bank.BankSystemException;
+import com.flab.coongyapay.bank.BankWithdrawalRejectedException;
+import com.flab.coongyapay.bank.BankWithdrawalStatus;
+import com.flab.coongyapay.bank.BankMaintenancePolicy;
 import com.flab.coongyapay.charge.service.ChargeCreditService;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
 import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.mapper.dto.RetryStateDto;
 import com.flab.coongyapay.transaction.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 /**
  * CHARGE 거래 상태머신을 전진시키는 워커.
- * CREATED → WITHDRAWING → (은행 출금) → WITHDRAWN → DEPOSITING → COMPLETED.
+ * 해피: CREATED → WITHDRAWING → WITHDRAWN → DEPOSITING → COMPLETED.
+ * 실패/불명: 4xx→FAILED(WITHDRAWAL_REJECTED), timeout/5xx→UNKNOWN(대사로 확정),
+ *           크레딧 transient→백오프 재시도, 영구→COMPENSATING(보상은 3D).
  *
- * 원칙: 은행 출금(withdraw)은 트랜잭션/락 밖, 크레딧(원장)은 wallet FOR UPDATE 트랜잭션 안.
- * 모든 상태 기록은 선점한 leaseToken으로 fencing → 리스 만료 후 재선점된 스테일 워커의 쓰기 차단.
- * (실패/UNKNOWN/보상은 3C/3D에서 확장)
+ * 원칙: 은행 호출은 트랜잭션/락 밖, 크레딧은 wallet FOR UPDATE 안. 모든 기록은 leaseToken 펜싱.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChargeProcessor {
 
+    private static final int FRESHNESS_MINUTES = 30;   // 미출금 확정 시 재시도 허용 window
+    private static final int REQUERY_CEILING = 5;      // UNKNOWN 재조회 상한(초과 시 NEEDS_REVIEW)
+    private static final int BASE_BACKOFF_SECONDS = 30; // 30s → 60s → 120s
+
     private final TransactionRepository transactionRepository;
     private final BankAccountRepository bankAccountRepository;
     private final BankClient bankClient;
+    private final BankMaintenancePolicy bankMaintenancePolicy;
     private final ChargeCreditService chargeCreditService;
+    private final Clock clock;
 
     public void process(Long transactionId, long leaseToken) {
         Transaction transaction = transactionRepository.findById(transactionId).orElse(null);
@@ -35,40 +54,129 @@ public class ChargeProcessor {
             return;
         }
 
-        TransactionStatus status = transaction.getStatus();
-
-        // 1. write-ahead 출금 의도 (CREATED → WITHDRAWING) + 외부 멱등키 확정
-        if (status == TransactionStatus.CREATED) {
-            boolean claimed = transactionRepository.updateStatusFenced(transactionId,
-                    TransactionStatus.CREATED, TransactionStatus.WITHDRAWING, null, null, leaseToken);
-            if (!claimed) {
-                return; // 펜싱: 다른 워커가 선점/전이
-            }
-            transactionRepository.assignExternalIdempotencyKey(transactionId, externalIdempotencyKey(transactionId));
-            status = TransactionStatus.WITHDRAWING;
-        }
-
-        // 2. 은행 출금 (외부, 락/트랜잭션 밖) → WITHDRAWN
-        if (status == TransactionStatus.WITHDRAWING) {
-            withdraw(transaction);
-            transactionRepository.updateStatusFenced(transactionId,
-                    TransactionStatus.WITHDRAWING, TransactionStatus.WITHDRAWN, null, null, leaseToken);
-            status = TransactionStatus.WITHDRAWN;
-        }
-
-        // 3. 크레딧 (WITHDRAWN → DEPOSITING → COMPLETED)
-        if (status == TransactionStatus.WITHDRAWN || status == TransactionStatus.DEPOSITING) {
-            transactionRepository.updateStatusFenced(transactionId,
-                    TransactionStatus.WITHDRAWN, TransactionStatus.DEPOSITING, null, null, leaseToken);
-            chargeCreditService.credit(transactionId, leaseToken);
+        switch (transaction.getStatus()) {
+            case CREATED -> startWithdrawal(transaction, leaseToken);
+            case WITHDRAWING -> executeWithdrawal(transaction, leaseToken);
+            case WITHDRAWN, DEPOSITING -> credit(transaction, leaseToken);
+            case UNKNOWN -> reconcileWithdrawal(transaction, leaseToken);
+            default -> { /* terminal 등: no-op */ }
         }
     }
 
-    private void withdraw(Transaction transaction) {
-        BankAccount account = bankAccountRepository.findById(transaction.getAccountId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
-        bankClient.withdraw(account.getBankCode(), account.getAccountNumber(),
-                transaction.getAmount(), externalIdempotencyKey(transaction.getId()));
+    // CREATED: 실행시점 점검시간 재확인 → write-ahead 의도 → 출금
+    private void startWithdrawal(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        if (bankMaintenancePolicy.isMaintenanceTime()) {
+            // 부작용 없음 → FAILED(BANK_MAINTENANCE)
+            transactionRepository.updateStatusFenced(id, TransactionStatus.CREATED,
+                    TransactionStatus.FAILED, TransactionFailureReason.BANK_MAINTENANCE, now(), leaseToken);
+            return;
+        }
+        boolean claimed = transactionRepository.updateStatusFenced(id, TransactionStatus.CREATED,
+                TransactionStatus.WITHDRAWING, null, null, leaseToken);
+        if (!claimed) {
+            return;
+        }
+        transactionRepository.assignExternalIdempotencyKey(id, externalIdempotencyKey(id));
+        executeWithdrawal(transaction, leaseToken);
+    }
+
+    // WITHDRAWING: 은행 출금(외부). 성공→WITHDRAWN→크레딧 / 4xx→FAILED / 불명→UNKNOWN
+    private void executeWithdrawal(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        try {
+            BankAccount account = bankAccountRepository.findById(transaction.getAccountId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+            bankClient.withdraw(account.getBankCode(), account.getAccountNumber(),
+                    transaction.getAmount(), externalIdempotencyKey(id));
+        } catch (BankWithdrawalRejectedException e) {
+            transactionRepository.updateStatusFenced(id, TransactionStatus.WITHDRAWING,
+                    TransactionStatus.FAILED, TransactionFailureReason.WITHDRAWAL_REJECTED, now(), leaseToken);
+            return;
+        } catch (BankSystemException e) {
+            // 결과 불명 → UNKNOWN (대사로 확정). 부작용을 확신할 수 없어 실패 처리하지 않음.
+            transactionRepository.updateStatusFenced(id, TransactionStatus.WITHDRAWING,
+                    TransactionStatus.UNKNOWN, null, null, leaseToken);
+            return;
+        }
+        transactionRepository.updateStatusFenced(id, TransactionStatus.WITHDRAWING,
+                TransactionStatus.WITHDRAWN, null, null, leaseToken);
+        credit(transaction, leaseToken);
+    }
+
+    // WITHDRAWN/DEPOSITING: 지갑 크레딧. transient→백오프 재시도, 영구(한도)→COMPENSATING(보상은 3D)
+    private void credit(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        transactionRepository.updateStatusFenced(id, TransactionStatus.WITHDRAWN,
+                TransactionStatus.DEPOSITING, null, null, leaseToken);
+        try {
+            chargeCreditService.credit(id, leaseToken);
+        } catch (TransientDataAccessException e) {
+            // 락 타임아웃/데드락 등 일시 실패 → 백오프 재시도
+            RetryStateDto retry = transactionRepository.findRetryState(id);
+            if (retry.getRetryCount() >= retry.getMaxRetries()) {
+                // 재시도 소진 → 후진 복구(보상) 개시. 보상 거래 생성/처리는 3D.
+                transactionRepository.updateStatusFenced(id, TransactionStatus.DEPOSITING,
+                        TransactionStatus.COMPENSATING, null, null, leaseToken);
+            } else {
+                transactionRepository.scheduleRetry(id, backoffSeconds(retry.getRetryCount()), leaseToken);
+            }
+        } catch (BusinessException e) {
+            // 한도 초과 등 영구 실패 → 즉시 보상 개시(재시도 무의미). 보상 처리는 3D.
+            transactionRepository.updateStatusFenced(id, TransactionStatus.DEPOSITING,
+                    TransactionStatus.COMPENSATING, null, null, leaseToken);
+        }
+    }
+
+    // UNKNOWN: 은행 대사로 출금 여부 확정
+    private void reconcileWithdrawal(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        BankWithdrawalStatus status = bankClient.getWithdrawalStatus(externalIdempotencyKey(id));
+        switch (status) {
+            case WITHDRAWN -> {
+                transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                        TransactionStatus.WITHDRAWN, null, null, leaseToken);
+                credit(transaction, leaseToken);
+            }
+            case NOT_WITHDRAWN -> {
+                RetryStateDto retry = transactionRepository.findRetryState(id);
+                if (isFresh(retry.getFirstAttemptAt())) {
+                    // 미출금 확정 + freshness 이내 → 같은 키로 재출금(UNKNOWN → WITHDRAWING)
+                    transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                            TransactionStatus.WITHDRAWING, null, null, leaseToken);
+                } else {
+                    // freshness 초과 → 예상치 못한 시점의 출금 방지 위해 실패 확정
+                    transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                            TransactionStatus.FAILED, TransactionFailureReason.WITHDRAWAL_NOT_COMPLETED, now(), leaseToken);
+                }
+            }
+            case UNKNOWN -> {
+                // 은행도 불명 → 재조회 카운트. 상한 초과 시 수동 개입(NEEDS_REVIEW), 아니면 백오프.
+                transactionRepository.incrementRequeryCount(id, leaseToken);
+                RetryStateDto retry = transactionRepository.findRetryState(id);
+                if (retry.getRequeryCount() >= REQUERY_CEILING) {
+                    transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                            TransactionStatus.NEEDS_REVIEW, null, null, leaseToken);
+                } else {
+                    transactionRepository.scheduleRetry(id, backoffSeconds(retry.getRetryCount()), leaseToken);
+                }
+            }
+        }
+    }
+
+    private boolean isFresh(LocalDateTime firstAttemptAt) {
+        if (firstAttemptAt == null) {
+            return true;
+        }
+        return Duration.between(firstAttemptAt, now()).toMinutes() <= FRESHNESS_MINUTES;
+    }
+
+    private int backoffSeconds(int retryCount) {
+        return BASE_BACKOFF_SECONDS * (1 << Math.min(retryCount, 3)); // 30,60,120,240 cap
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(clock);
     }
 
     private String externalIdempotencyKey(Long transactionId) {

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeProcessor.java
@@ -13,12 +13,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
- * CHARGE 거래 상태머신을 전진시키는 워커(3A 해피패스).
+ * CHARGE 거래 상태머신을 전진시키는 워커.
  * CREATED → WITHDRAWING → (은행 출금) → WITHDRAWN → DEPOSITING → COMPLETED.
  *
- * 핵심 원칙: 은행 출금(withdraw)은 트랜잭션/락 밖에서, 크레딧(원장 기록)은 wallet FOR UPDATE 트랜잭션 안에서.
- * 상태 전이는 CAS(updateStatus)로 처리해 중복 처리를 방지한다.
- * (재시도/UNKNOWN/보상/펜싱은 3B~3D에서 확장)
+ * 원칙: 은행 출금(withdraw)은 트랜잭션/락 밖, 크레딧(원장)은 wallet FOR UPDATE 트랜잭션 안.
+ * 모든 상태 기록은 선점한 leaseToken으로 fencing → 리스 만료 후 재선점된 스테일 워커의 쓰기 차단.
+ * (실패/UNKNOWN/보상은 3C/3D에서 확장)
  */
 @Component
 @RequiredArgsConstructor
@@ -29,7 +29,7 @@ public class ChargeProcessor {
     private final BankClient bankClient;
     private final ChargeCreditService chargeCreditService;
 
-    public void process(Long transactionId) {
+    public void process(Long transactionId, long leaseToken) {
         Transaction transaction = transactionRepository.findById(transactionId).orElse(null);
         if (transaction == null || !transaction.isCharge()) {
             return;
@@ -37,24 +37,30 @@ public class ChargeProcessor {
 
         TransactionStatus status = transaction.getStatus();
 
-        // 1. 출금 단계 (CREATED 진입): write-ahead 의도 후 외부 출금 → WITHDRAWN
+        // 1. write-ahead 출금 의도 (CREATED → WITHDRAWING) + 외부 멱등키 확정
         if (status == TransactionStatus.CREATED) {
-            boolean claimed = transactionRepository.updateStatus(transactionId,
-                    TransactionStatus.CREATED, TransactionStatus.WITHDRAWING, null, null);
+            boolean claimed = transactionRepository.updateStatusFenced(transactionId,
+                    TransactionStatus.CREATED, TransactionStatus.WITHDRAWING, null, null, leaseToken);
             if (!claimed) {
-                return; // 다른 워커가 선점
+                return; // 펜싱: 다른 워커가 선점/전이
             }
+            transactionRepository.assignExternalIdempotencyKey(transactionId, externalIdempotencyKey(transactionId));
+            status = TransactionStatus.WITHDRAWING;
+        }
+
+        // 2. 은행 출금 (외부, 락/트랜잭션 밖) → WITHDRAWN
+        if (status == TransactionStatus.WITHDRAWING) {
             withdraw(transaction);
-            transactionRepository.updateStatus(transactionId,
-                    TransactionStatus.WITHDRAWING, TransactionStatus.WITHDRAWN, null, null);
+            transactionRepository.updateStatusFenced(transactionId,
+                    TransactionStatus.WITHDRAWING, TransactionStatus.WITHDRAWN, null, null, leaseToken);
             status = TransactionStatus.WITHDRAWN;
         }
 
-        // 2. 크레딧 단계 (WITHDRAWN/DEPOSITING): 지갑 반영 → COMPLETED
+        // 3. 크레딧 (WITHDRAWN → DEPOSITING → COMPLETED)
         if (status == TransactionStatus.WITHDRAWN || status == TransactionStatus.DEPOSITING) {
-            transactionRepository.updateStatus(transactionId,
-                    TransactionStatus.WITHDRAWN, TransactionStatus.DEPOSITING, null, null);
-            chargeCreditService.credit(transactionId);
+            transactionRepository.updateStatusFenced(transactionId,
+                    TransactionStatus.WITHDRAWN, TransactionStatus.DEPOSITING, null, null, leaseToken);
+            chargeCreditService.credit(transactionId, leaseToken);
         }
     }
 

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeWorker.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeWorker.java
@@ -1,0 +1,40 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 진행 가능한 CHARGE 거래를 주기적으로 폴링해 상태머신을 전진시키는 스케줄 워커.
+ * 202 응답의 내구성은 이 워커가 보장한다(@Async fast-path는 3B에서 추가).
+ *
+ * charge.worker.enabled=false 로 비활성화 가능(테스트는 process()를 직접 호출).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "charge.worker.enabled", havingValue = "true", matchIfMissing = true)
+public class ChargeWorker {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final TransactionRepository transactionRepository;
+    private final ChargeProcessor chargeProcessor;
+
+    @Scheduled(fixedDelayString = "${charge.worker.fixed-delay-ms:2000}")
+    public void poll() {
+        List<Long> ids = transactionRepository.findProcessableChargeIds(BATCH_SIZE);
+        for (Long id : ids) {
+            try {
+                chargeProcessor.process(id);
+            } catch (Exception e) {
+                log.warn("Charge processing failed: transactionId={}", id, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/ChargeWorker.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ChargeWorker.java
@@ -1,40 +1,25 @@
 package com.flab.coongyapay.charge.worker;
 
-import com.flab.coongyapay.transaction.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
- * 진행 가능한 CHARGE 거래를 주기적으로 폴링해 상태머신을 전진시키는 스케줄 워커.
- * 202 응답의 내구성은 이 워커가 보장한다(@Async fast-path는 3B에서 추가).
+ * 진행 가능한 CHARGE 거래를 주기적으로 선점(lease)·처리하는 내구 워커.
+ * 202 응답 이후의 완료 보장을 책임진다.
  *
- * charge.worker.enabled=false 로 비활성화 가능(테스트는 process()를 직접 호출).
+ * charge.worker.enabled=false 로 비활성화(테스트는 claim/process를 직접 호출).
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "charge.worker.enabled", havingValue = "true", matchIfMissing = true)
 public class ChargeWorker {
 
-    private static final int BATCH_SIZE = 50;
-
-    private final TransactionRepository transactionRepository;
-    private final ChargeProcessor chargeProcessor;
+    private final ChargeDispatcher chargeDispatcher;
 
     @Scheduled(fixedDelayString = "${charge.worker.fixed-delay-ms:2000}")
     public void poll() {
-        List<Long> ids = transactionRepository.findProcessableChargeIds(BATCH_SIZE);
-        for (Long id : ids) {
-            try {
-                chargeProcessor.process(id);
-            } catch (Exception e) {
-                log.warn("Charge processing failed: transactionId={}", id, e);
-            }
-        }
+        chargeDispatcher.runOnce();
     }
 }

--- a/src/main/java/com/flab/coongyapay/charge/worker/ClaimedTransaction.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/ClaimedTransaction.java
@@ -1,0 +1,7 @@
+package com.flab.coongyapay.charge.worker;
+
+/**
+ * 워커가 선점한 거래. leaseToken은 이후 결과 기록 시 fencing(WHERE lease_token=?)에 사용한다.
+ */
+public record ClaimedTransaction(Long id, long leaseToken) {
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/CompensationClaimService.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/CompensationClaimService.java
@@ -11,27 +11,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * "짧게 선점": FOR UPDATE SKIP LOCKED로 진행 가능한 거래를 골라 즉시 lease를 세팅(짧은 트랜잭션).
- * 트랜잭션 커밋으로 행 락은 풀리지만 lease가 유효한 동안 다른 워커의 재선점을 막는다.
+ * 보상(COMPENSATION) 거래 선점. CHARGE 워커와 동일한 lease/fencing 인프라를 재사용한다.
  */
 @Service
 @RequiredArgsConstructor
-public class ChargeClaimService {
+public class CompensationClaimService {
 
-    // 워커가 전진시킬 비종료 상태들(UNKNOWN=대사, COMPENSATING=보상 안전망 포함)
     private static final List<TransactionStatus> CLAIMABLE_STATUSES = List.of(
             TransactionStatus.CREATED,
-            TransactionStatus.WITHDRAWING,
-            TransactionStatus.WITHDRAWN,
-            TransactionStatus.DEPOSITING,
-            TransactionStatus.UNKNOWN,
-            TransactionStatus.COMPENSATING);
+            TransactionStatus.REFUNDING,
+            TransactionStatus.UNKNOWN);
 
     private final TransactionRepository transactionRepository;
 
     @Transactional
     public List<ClaimedTransaction> claimBatch(int limit, int leaseSeconds) {
-        List<Long> ids = transactionRepository.selectClaimableIds(TransactionType.CHARGE, CLAIMABLE_STATUSES, limit);
+        List<Long> ids = transactionRepository.selectClaimableIds(TransactionType.COMPENSATION, CLAIMABLE_STATUSES, limit);
         List<ClaimedTransaction> claimed = new ArrayList<>(ids.size());
         for (Long id : ids) {
             transactionRepository.acquireLease(id, leaseSeconds);

--- a/src/main/java/com/flab/coongyapay/charge/worker/CompensationProcessor.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/CompensationProcessor.java
@@ -1,0 +1,134 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.bank.BankClient;
+import com.flab.coongyapay.bank.BankRefundStatus;
+import com.flab.coongyapay.bank.BankSystemException;
+import com.flab.coongyapay.bank.BankWithdrawalRejectedException;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.mapper.dto.RetryStateDto;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+/**
+ * 보상(환불) 거래 상태머신 B.
+ * CREATED → REFUNDING → (은행 환불) → COMPLETED → 부모 CHARGE COMPENSATING→FAILED(REFUNDED).
+ * 불명(UNKNOWN)은 대사로 확정, 재조회 상한 초과 시 NEEDS_REVIEW(수동 개입, 부모는 COMPENSATING 유지).
+ */
+@Component
+@RequiredArgsConstructor
+public class CompensationProcessor {
+
+    private static final int REQUERY_CEILING = 5;
+    private static final int BASE_BACKOFF_SECONDS = 30;
+
+    private final TransactionRepository transactionRepository;
+    private final BankAccountRepository bankAccountRepository;
+    private final BankClient bankClient;
+    private final Clock clock;
+
+    public void process(Long transactionId, long leaseToken) {
+        Transaction transaction = transactionRepository.findById(transactionId).orElse(null);
+        if (transaction == null || transaction.getTransactionType() != TransactionType.COMPENSATION) {
+            return;
+        }
+
+        switch (transaction.getStatus()) {
+            case CREATED -> startRefund(transaction, leaseToken);
+            case REFUNDING -> executeRefund(transaction, leaseToken);
+            case UNKNOWN -> reconcileRefund(transaction, leaseToken);
+            default -> { /* terminal 등: no-op */ }
+        }
+    }
+
+    private void startRefund(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        boolean moved = transactionRepository.updateStatusFenced(id, TransactionStatus.CREATED,
+                TransactionStatus.REFUNDING, null, null, leaseToken);
+        if (!moved) {
+            return;
+        }
+        transactionRepository.assignExternalIdempotencyKey(id, externalIdempotencyKey(id));
+        executeRefund(transaction, leaseToken);
+    }
+
+    private void executeRefund(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        try {
+            BankAccount account = bankAccountRepository.findById(transaction.getAccountId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+            bankClient.refund(account.getBankCode(), account.getAccountNumber(),
+                    transaction.getAmount(), externalIdempotencyKey(id));
+        } catch (BankWithdrawalRejectedException | BankSystemException e) {
+            // 환불 실패/불명 → UNKNOWN(대사로 확정). 돈을 돌려줘야 하므로 실패로 종결하지 않음.
+            transactionRepository.updateStatusFenced(id, TransactionStatus.REFUNDING,
+                    TransactionStatus.UNKNOWN, null, null, leaseToken);
+            return;
+        }
+        boolean done = transactionRepository.updateStatusFenced(id, TransactionStatus.REFUNDING,
+                TransactionStatus.COMPLETED, null, now(), leaseToken);
+        if (done) {
+            completeParent(transaction.getParentTransactionId());
+        }
+    }
+
+    private void reconcileRefund(Transaction transaction, long leaseToken) {
+        Long id = transaction.getId();
+        BankRefundStatus status = bankClient.getRefundStatus(externalIdempotencyKey(id));
+        switch (status) {
+            case REFUNDED -> {
+                boolean done = transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                        TransactionStatus.COMPLETED, null, now(), leaseToken);
+                if (done) {
+                    completeParent(transaction.getParentTransactionId());
+                }
+            }
+            case NOT_REFUNDED ->
+                // 미환불 확정 → 재환불 의도(UNKNOWN → REFUNDING). 돈은 반드시 돌려줘야 함.
+                    transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                            TransactionStatus.REFUNDING, null, null, leaseToken);
+            case UNKNOWN -> {
+                transactionRepository.incrementRequeryCount(id, leaseToken);
+                RetryStateDto retry = transactionRepository.findRetryState(id);
+                if (retry.getRequeryCount() >= REQUERY_CEILING) {
+                    // 상한 초과 → 수동 개입. 부모는 COMPENSATING 유지(이중 환불 방지).
+                    transactionRepository.updateStatusFenced(id, TransactionStatus.UNKNOWN,
+                            TransactionStatus.NEEDS_REVIEW, null, null, leaseToken);
+                } else {
+                    transactionRepository.scheduleRetry(id, backoffSeconds(retry.getRetryCount()), leaseToken);
+                }
+            }
+        }
+    }
+
+    // 자식 보상 완료 → 부모 CHARGE COMPENSATING → FAILED(REFUNDED)
+    private void completeParent(Long parentTransactionId) {
+        if (parentTransactionId == null) {
+            return;
+        }
+        transactionRepository.updateStatus(parentTransactionId, TransactionStatus.COMPENSATING,
+                TransactionStatus.FAILED, TransactionFailureReason.REFUNDED, now());
+    }
+
+    private int backoffSeconds(int retryCount) {
+        return BASE_BACKOFF_SECONDS * (1 << Math.min(retryCount, 3));
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(clock);
+    }
+
+    private String externalIdempotencyKey(Long transactionId) {
+        return "refund-" + transactionId;
+    }
+}

--- a/src/main/java/com/flab/coongyapay/charge/worker/CompensationWorker.java
+++ b/src/main/java/com/flab/coongyapay/charge/worker/CompensationWorker.java
@@ -1,0 +1,38 @@
+package com.flab.coongyapay.charge.worker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 보상(환불) 거래를 주기적으로 선점·처리하는 내구 워커. CHARGE 워커와 동일 인프라 재사용.
+ * charge.worker.enabled=false 로 비활성화(테스트는 claim/process를 직접 호출).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "charge.worker.enabled", havingValue = "true", matchIfMissing = true)
+public class CompensationWorker {
+
+    private static final int BATCH_SIZE = 50;
+    private static final int LEASE_SECONDS = 30;
+
+    private final CompensationClaimService compensationClaimService;
+    private final CompensationProcessor compensationProcessor;
+
+    @Scheduled(fixedDelayString = "${charge.worker.fixed-delay-ms:2000}")
+    public void poll() {
+        List<ClaimedTransaction> claimed = compensationClaimService.claimBatch(BATCH_SIZE, LEASE_SECONDS);
+        for (ClaimedTransaction transaction : claimed) {
+            try {
+                compensationProcessor.process(transaction.id(), transaction.leaseToken());
+            } catch (Exception e) {
+                log.warn("Compensation processing failed: transactionId={}", transaction.id(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
     BANK_MAINTENANCE("BANK_MAINTENANCE", HttpStatus.BAD_REQUEST, "은행 점검 시간(00:00~00:30)에는 송금할 수 없습니다."),
     WALLET_BALANCE_LIMIT_EXCEEDED("WALLET_BALANCE_LIMIT_EXCEEDED", HttpStatus.BAD_REQUEST, "페이머니 보유 한도(2,000,000원)를 초과할 수 없습니다."),
 
+    //Transaction
+    TRANSACTION_NOT_FOUND("TRANSACTION_NOT_FOUND", HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
+
     //Internal Server Error
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다.");
 

--- a/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
@@ -40,6 +40,18 @@ public enum ErrorCode {
     //Bank
     BANK_SYSTEM_UNAVAILABLE("BANK_SYSTEM_UNAVAILABLE", HttpStatus.SERVICE_UNAVAILABLE, "은행 시스템에 일시적인 장애가 발생했습니다."),
 
+    //Charge
+    INVALID_IDEMPOTENCY_KEY("INVALID_IDEMPOTENCY_KEY", HttpStatus.BAD_REQUEST, "멱등키가 없거나 형식이 올바르지 않습니다."),
+    IDEMPOTENCY_KEY_PROCESSING("IDEMPOTENCY_KEY_PROCESSING", HttpStatus.CONFLICT, "이전 요청이 처리 중입니다. 잠시 후 상태를 조회해주세요."),
+    IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.BAD_REQUEST, "동일한 멱등키로 다른 요청은 처리할 수 없습니다."),
+    INVALID_CHARGE_AMOUNT("INVALID_CHARGE_AMOUNT", HttpStatus.BAD_REQUEST, "충전 금액은 1원 이상 2,000,000원 이하여야 합니다."),
+    INVALID_REMARK_LENGTH("INVALID_REMARK_LENGTH", HttpStatus.BAD_REQUEST, "거래 적요는 최소 1자, 최대 7자까지 입력할 수 있습니다."),
+    INVALID_TRANSFER_PIN("INVALID_TRANSFER_PIN", HttpStatus.UNAUTHORIZED, "송금 비밀번호를 확인해주세요."),
+    TRANSFER_PIN_LOCKED("TRANSFER_PIN_LOCKED", HttpStatus.LOCKED, "송금 비밀번호 5회 오류로 잠겼습니다."),
+    INVALID_SENDER_ACCOUNT("INVALID_SENDER_ACCOUNT", HttpStatus.BAD_REQUEST, "출금 계좌가 존재하지 않거나 거래할 수 없는 상태입니다."),
+    BANK_MAINTENANCE("BANK_MAINTENANCE", HttpStatus.BAD_REQUEST, "은행 점검 시간(00:00~00:30)에는 송금할 수 없습니다."),
+    WALLET_BALANCE_LIMIT_EXCEEDED("WALLET_BALANCE_LIMIT_EXCEEDED", HttpStatus.BAD_REQUEST, "페이머니 보유 한도(2,000,000원)를 초과할 수 없습니다."),
+
     //Internal Server Error
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다.");
 

--- a/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/coongyapay/common/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
     //Charge
     INVALID_IDEMPOTENCY_KEY("INVALID_IDEMPOTENCY_KEY", HttpStatus.BAD_REQUEST, "멱등키가 없거나 형식이 올바르지 않습니다."),
     IDEMPOTENCY_KEY_PROCESSING("IDEMPOTENCY_KEY_PROCESSING", HttpStatus.CONFLICT, "이전 요청이 처리 중입니다. 잠시 후 상태를 조회해주세요."),
-    IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.BAD_REQUEST, "동일한 멱등키로 다른 요청은 처리할 수 없습니다."),
+    IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.UNPROCESSABLE_CONTENT, "동일한 멱등키로 다른 요청은 처리할 수 없습니다."),
     INVALID_CHARGE_AMOUNT("INVALID_CHARGE_AMOUNT", HttpStatus.BAD_REQUEST, "충전 금액은 1원 이상 2,000,000원 이하여야 합니다."),
     INVALID_REMARK_LENGTH("INVALID_REMARK_LENGTH", HttpStatus.BAD_REQUEST, "거래 적요는 최소 1자, 최대 7자까지 입력할 수 있습니다."),
     INVALID_TRANSFER_PIN("INVALID_TRANSFER_PIN", HttpStatus.UNAUTHORIZED, "송금 비밀번호를 확인해주세요."),

--- a/src/main/java/com/flab/coongyapay/common/util/RequestHashUtil.java
+++ b/src/main/java/com/flab/coongyapay/common/util/RequestHashUtil.java
@@ -1,0 +1,20 @@
+package com.flab.coongyapay.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public class RequestHashUtil {
+
+    private RequestHashUtil() {}
+
+    public static String sha256Hex(String input) {
+        try {
+            byte[] bytes = MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not supported", e);
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/config/ClockConfig.java
+++ b/src/main/java/com/flab/coongyapay/config/ClockConfig.java
@@ -1,0 +1,16 @@
+package com.flab.coongyapay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/com/flab/coongyapay/config/SchedulingConfig.java
+++ b/src/main/java/com/flab/coongyapay/config/SchedulingConfig.java
@@ -1,9 +1,11 @@
 package com.flab.coongyapay.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@EnableAsync
 public class SchedulingConfig {
 }

--- a/src/main/java/com/flab/coongyapay/config/SchedulingConfig.java
+++ b/src/main/java/com/flab/coongyapay/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.flab.coongyapay.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/assembler/IdempotencyAssembler.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/assembler/IdempotencyAssembler.java
@@ -1,0 +1,18 @@
+package com.flab.coongyapay.idempotency.assembler;
+
+import com.flab.coongyapay.idempotency.domain.IdempotencyRecord;
+import com.flab.coongyapay.idempotency.enums.IdempotencyStatus;
+import com.flab.coongyapay.idempotency.mapper.dto.IdempotencyRecordDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdempotencyAssembler {
+
+    public IdempotencyRecordDto toDto(IdempotencyRecord domain) {
+        return new IdempotencyRecordDto(domain.getUserId(), domain.getEndpoint(), domain.getIdempotencyKey(), domain.getRequestHash(), domain.getStatus().name(), domain.getResponseHttpStatus(), domain.getResponseBody(), null, null);
+    }
+
+    public IdempotencyRecord toDomain(IdempotencyRecordDto dto) {
+        return IdempotencyRecord.from(dto.getUserId(), dto.getEndpoint(), dto.getIdempotencyKey(), dto.getRequestHash(), dto.getStatus() == null ? null : IdempotencyStatus.valueOf(dto.getStatus()), dto.getResponseHttpStatus(), dto.getResponseBody());
+    }
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/domain/IdempotencyRecord.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/domain/IdempotencyRecord.java
@@ -1,0 +1,33 @@
+package com.flab.coongyapay.idempotency.domain;
+
+import com.flab.coongyapay.idempotency.enums.IdempotencyStatus;
+import lombok.Getter;
+
+@Getter
+public class IdempotencyRecord {
+    private final Long userId;
+    private final String endpoint;
+    private final String idempotencyKey;
+    private final String requestHash;
+    private final IdempotencyStatus status;
+    private final Integer responseHttpStatus;
+    private final String responseBody;
+
+    private IdempotencyRecord(Long userId, String endpoint, String idempotencyKey, String requestHash, IdempotencyStatus status, Integer responseHttpStatus, String responseBody) {
+        this.userId = userId;
+        this.endpoint = endpoint;
+        this.idempotencyKey = idempotencyKey;
+        this.requestHash = requestHash;
+        this.status = status;
+        this.responseHttpStatus = responseHttpStatus;
+        this.responseBody = responseBody;
+    }
+
+    public static IdempotencyRecord create(Long userId, String endpoint, String idempotencyKey, String requestHash) {
+        return new IdempotencyRecord(userId, endpoint, idempotencyKey, requestHash, IdempotencyStatus.PROCESSING, null, null);
+    }
+
+    public static IdempotencyRecord from(Long userId, String endpoint, String idempotencyKey, String requestHash, IdempotencyStatus status, Integer responseHttpStatus, String responseBody) {
+        return new IdempotencyRecord(userId, endpoint, idempotencyKey, requestHash, status, responseHttpStatus, responseBody);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/enums/IdempotencyStatus.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/enums/IdempotencyStatus.java
@@ -1,0 +1,6 @@
+package com.flab.coongyapay.idempotency.enums;
+
+public enum IdempotencyStatus {
+    PROCESSING,
+    COMPLETED
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/mapper/IdempotencyMapper.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/mapper/IdempotencyMapper.java
@@ -1,0 +1,21 @@
+package com.flab.coongyapay.idempotency.mapper;
+
+import com.flab.coongyapay.idempotency.mapper.dto.IdempotencyRecordDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+
+@Mapper
+public interface IdempotencyMapper {
+
+    void insert(@Param("record") IdempotencyRecordDto record, @Param("leaseSeconds") long leaseSeconds, @Param("ttlSeconds") long ttlSeconds);
+
+    Optional<IdempotencyRecordDto> findByPk(@Param("userId") Long userId, @Param("endpoint") String endpoint, @Param("idempotencyKey") String idempotencyKey);
+
+    int reclaim(@Param("userId") Long userId, @Param("endpoint") String endpoint, @Param("idempotencyKey") String idempotencyKey, @Param("leaseSeconds") long leaseSeconds);
+
+    int complete(@Param("userId") Long userId, @Param("endpoint") String endpoint, @Param("idempotencyKey") String idempotencyKey, @Param("responseHttpStatus") int responseHttpStatus, @Param("responseBody") String responseBody);
+
+    int delete(@Param("userId") Long userId, @Param("endpoint") String endpoint, @Param("idempotencyKey") String idempotencyKey);
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/mapper/dto/IdempotencyRecordDto.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/mapper/dto/IdempotencyRecordDto.java
@@ -1,0 +1,24 @@
+package com.flab.coongyapay.idempotency.mapper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdempotencyRecordDto {
+    private Long userId;
+    private String endpoint;
+    private String idempotencyKey;
+    private String requestHash;
+    private String status;
+    private Integer responseHttpStatus;
+    private String responseBody;
+    private LocalDateTime leaseExpiresAt;
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/repository/IdempotencyRepository.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/repository/IdempotencyRepository.java
@@ -1,0 +1,50 @@
+package com.flab.coongyapay.idempotency.repository;
+
+import com.flab.coongyapay.idempotency.assembler.IdempotencyAssembler;
+import com.flab.coongyapay.idempotency.domain.IdempotencyRecord;
+import com.flab.coongyapay.idempotency.mapper.IdempotencyMapper;
+import com.flab.coongyapay.idempotency.mapper.dto.IdempotencyRecordDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class IdempotencyRepository {
+
+    public static final int LEASE_SECONDS = 120;
+    public static final int TTL_SECONDS = 86_400;
+
+    private final IdempotencyMapper idempotencyMapper;
+    private final IdempotencyAssembler idempotencyAssembler;
+
+    public boolean tryInsertProcessing(IdempotencyRecord idempotencyRecord) {
+        try {
+            IdempotencyRecordDto dto = idempotencyAssembler.toDto(idempotencyRecord);
+            idempotencyMapper.insert(dto, LEASE_SECONDS, TTL_SECONDS);
+            return true;
+        } catch (DuplicateKeyException e) {
+            return false;
+        }
+    }
+
+    public Optional<IdempotencyRecord> findByPk(Long userId, String endpoint, String idempotencyKey) {
+        return idempotencyMapper.findByPk(userId, endpoint, idempotencyKey).map(idempotencyAssembler::toDomain);
+    }
+
+    public boolean reclaim(Long userId, String endpoint, String idempotencyKey) {
+        int reclaimed = idempotencyMapper.reclaim(userId, endpoint, idempotencyKey, LEASE_SECONDS);
+        return reclaimed == 1;
+    }
+
+    public boolean complete(Long userId, String endpoint, String idempotencyKey, int responseHttpStatus, String responseBody) {
+        int completed = idempotencyMapper.complete(userId, endpoint, idempotencyKey, responseHttpStatus, responseBody);
+        return completed == 1;
+    }
+
+    public void release(Long userId, String endpoint, String idempotencyKey) {
+        idempotencyMapper.delete(userId, endpoint, idempotencyKey);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/service/ClaimResult.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/service/ClaimResult.java
@@ -1,0 +1,21 @@
+package com.flab.coongyapay.idempotency.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ClaimResult {
+
+    private final boolean replayed;
+    private final Integer responseHttpStatus;
+    private final String cachedResponseBody;
+
+    public static ClaimResult newRequest() {
+        return new ClaimResult(false, null, null);
+    }
+
+    public static ClaimResult replay(int responseHttpStatus, String cachedResponseBody) {
+        return new ClaimResult(true, responseHttpStatus, cachedResponseBody);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/idempotency/service/IdempotencyService.java
+++ b/src/main/java/com/flab/coongyapay/idempotency/service/IdempotencyService.java
@@ -1,0 +1,53 @@
+package com.flab.coongyapay.idempotency.service;
+
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.idempotency.domain.IdempotencyRecord;
+import com.flab.coongyapay.idempotency.enums.IdempotencyStatus;
+import com.flab.coongyapay.idempotency.repository.IdempotencyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final IdempotencyRepository idempotencyRepository;
+
+    public ClaimResult claim(Long userId, String endpoint, String idempotencyKey, String requestHash) {
+        IdempotencyRecord record = IdempotencyRecord.create(userId, endpoint, idempotencyKey, requestHash);
+        boolean claimed = idempotencyRepository.tryInsertProcessing(record);
+        if (claimed) {
+            return ClaimResult.newRequest();
+        }
+
+        IdempotencyRecord existingRecord = idempotencyRepository.findByPk(userId, endpoint, idempotencyKey)
+                .orElseThrow(() -> new BusinessException(ErrorCode.IDEMPOTENCY_KEY_PROCESSING));
+
+        if (!existingRecord.getRequestHash().equals(requestHash)) {
+            throw new BusinessException(ErrorCode.IDEMPOTENCY_KEY_CONFLICT);
+        }
+
+        if (IdempotencyStatus.COMPLETED == existingRecord.getStatus()) {
+            return ClaimResult.replay(existingRecord.getResponseHttpStatus(), existingRecord.getResponseBody());
+        }
+
+        boolean reclaimed = idempotencyRepository.reclaim(userId, endpoint, idempotencyKey);
+        if (reclaimed) {
+            return ClaimResult.newRequest();
+        } else {
+            throw new BusinessException(ErrorCode.IDEMPOTENCY_KEY_PROCESSING);
+        }
+    }
+
+    public void complete(Long userId, String endpoint, String idempotencyKey, int responseHttpStatus, String responseBody) {
+        boolean completed = idempotencyRepository.complete(userId, endpoint, idempotencyKey, responseHttpStatus, responseBody);
+        if (!completed) {
+            throw new BusinessException(ErrorCode.IDEMPOTENCY_KEY_PROCESSING);
+        }
+    }
+
+    public void release(Long userId, String endpoint, String idempotencyKey) {
+        idempotencyRepository.release(userId, endpoint, idempotencyKey);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/reconciliation/ReconciliationService.java
+++ b/src/main/java/com/flab/coongyapay/reconciliation/ReconciliationService.java
@@ -1,0 +1,60 @@
+package com.flab.coongyapay.reconciliation;
+
+import com.flab.coongyapay.reconciliation.mapper.ReconciliationMapper;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * 대사·정합성·모니터링. 스케줄로 주기 실행되며, 수렴이 멈춘 지점을 탐지·알림한다.
+ * charge.worker.enabled=false 로 스케줄 비활성화(테스트는 메서드를 직접 호출하거나 매퍼 단위테스트).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "charge.worker.enabled", havingValue = "true", matchIfMissing = true)
+public class ReconciliationService {
+
+    private static final int IDLE_EXPIRE_SECONDS = 600;       // CREATED 유휴 만료 임계(10분)
+    private static final int NON_TERMINAL_DWELL_MINUTES = 5;  // 체류 경보 임계
+
+    private final ReconciliationMapper reconciliationMapper;
+
+    // 유휴 CREATED(부작용 없음) 만료. WITHDRAWING/UNKNOWN은 만료 대상 아님(출금 위험).
+    @Scheduled(fixedDelayString = "${reconciliation.expire-delay-ms:60000}")
+    public void expireIdleCreated() {
+        int expired = reconciliationMapper.expireIdleCreatedCharges(IDLE_EXPIRE_SECONDS);
+        if (expired > 0) {
+            log.info("Reconciliation: expired {} idle CREATED charges", expired);
+        }
+    }
+
+    // 내부 3-테이블 불변식 검증 (위반=인시던트)
+    @Scheduled(fixedDelayString = "${reconciliation.invariant-delay-ms:300000}")
+    public void verifyInvariants() {
+        int balanceMismatch = reconciliationMapper.countBalanceMismatches();
+        int versionViolation = reconciliationMapper.countVersionIntegrityViolations();
+        int creditViolation = reconciliationMapper.countCompletedChargesWithoutSingleCredit();
+        if (balanceMismatch > 0 || versionViolation > 0 || creditViolation > 0) {
+            log.error("Reconciliation INVARIANT VIOLATION: balanceMismatch={}, versionViolation={}, completedChargeCreditViolation={}",
+                    balanceMismatch, versionViolation, creditViolation);
+        }
+    }
+
+    // 수렴 정체 모니터링: NEEDS_REVIEW(0이 정상), 장기 체류, UNKNOWN 적체
+    @Scheduled(fixedDelayString = "${reconciliation.monitor-delay-ms:60000}")
+    public void reportMetrics() {
+        int needsReview = reconciliationMapper.countByStatus(TransactionStatus.NEEDS_REVIEW.name());
+        int unknown = reconciliationMapper.countByStatus(TransactionStatus.UNKNOWN.name());
+        int stuck = reconciliationMapper.countNonTerminalOlderThanMinutes(NON_TERMINAL_DWELL_MINUTES);
+        if (needsReview > 0) {
+            log.error("Monitoring: NEEDS_REVIEW={} (수동 개입 필요)", needsReview);
+        }
+        if (stuck > 0 || unknown > 0) {
+            log.warn("Monitoring: non-terminal dwell(>{}m)={}, UNKNOWN={}", NON_TERMINAL_DWELL_MINUTES, stuck, unknown);
+        }
+    }
+}

--- a/src/main/java/com/flab/coongyapay/reconciliation/mapper/ReconciliationMapper.java
+++ b/src/main/java/com/flab/coongyapay/reconciliation/mapper/ReconciliationMapper.java
@@ -1,0 +1,23 @@
+package com.flab.coongyapay.reconciliation.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ReconciliationMapper {
+
+    // 유휴 CREATED(부작용 없음) → EXPIRED. WITHDRAWING/UNKNOWN은 절대 만료하지 않음(출금 위험).
+    int expireIdleCreatedCharges(@Param("idleSeconds") int idleSeconds);
+
+    // 내부 정합성 불변식 위반 건수 (0이 정상)
+    int countBalanceMismatches();
+
+    int countVersionIntegrityViolations();
+
+    int countCompletedChargesWithoutSingleCredit();
+
+    // 모니터링 지표
+    int countNonTerminalOlderThanMinutes(@Param("minutes") int minutes);
+
+    int countByStatus(@Param("status") String status);
+}

--- a/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionAssembler.java
+++ b/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionAssembler.java
@@ -1,0 +1,20 @@
+package com.flab.coongyapay.transaction.assembler;
+
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TransactionAssembler {
+
+    public TransactionDto toDto(Transaction domain) {
+        return new TransactionDto(domain.getId(), domain.getWalletId(), domain.getTransactionType().name(), domain.getParentTransactionId(), domain.getAmount(), domain.getStatus().name(), domain.getRemark(), domain.getFailureReason() == null ? null : domain.getFailureReason().name(), domain.getCreatedAt(), domain.getCompletedAt());
+    }
+
+    public Transaction toDomain(TransactionDto dto) {
+        return Transaction.from(dto.getId(), dto.getWalletId(), TransactionType.valueOf(dto.getTransactionType()), dto.getParentTransactionId(), dto.getAmount(), TransactionStatus.valueOf(dto.getStatus()), dto.getRemark(), dto.getFailureReason() == null ? null : TransactionFailureReason.valueOf(dto.getFailureReason()), dto.getCreatedAt(), dto.getCompletedAt());
+    }
+}

--- a/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionAssembler.java
+++ b/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionAssembler.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 public class TransactionAssembler {
 
     public TransactionDto toDto(Transaction domain) {
-        return new TransactionDto(domain.getId(), domain.getWalletId(), domain.getTransactionType().name(), domain.getParentTransactionId(), domain.getAmount(), domain.getStatus().name(), domain.getRemark(), domain.getFailureReason() == null ? null : domain.getFailureReason().name(), domain.getCreatedAt(), domain.getCompletedAt());
+        return new TransactionDto(domain.getId(), domain.getWalletId(), domain.getAccountId(), domain.getTransactionType().name(), domain.getParentTransactionId(), domain.getAmount(), domain.getStatus().name(), domain.getRemark(), domain.getFailureReason() == null ? null : domain.getFailureReason().name(), domain.getCreatedAt(), domain.getCompletedAt());
     }
 
     public Transaction toDomain(TransactionDto dto) {
-        return Transaction.from(dto.getId(), dto.getWalletId(), TransactionType.valueOf(dto.getTransactionType()), dto.getParentTransactionId(), dto.getAmount(), TransactionStatus.valueOf(dto.getStatus()), dto.getRemark(), dto.getFailureReason() == null ? null : TransactionFailureReason.valueOf(dto.getFailureReason()), dto.getCreatedAt(), dto.getCompletedAt());
+        return Transaction.from(dto.getId(), dto.getWalletId(), dto.getAccountId(), TransactionType.valueOf(dto.getTransactionType()), dto.getParentTransactionId(), dto.getAmount(), TransactionStatus.valueOf(dto.getStatus()), dto.getRemark(), dto.getFailureReason() == null ? null : TransactionFailureReason.valueOf(dto.getFailureReason()), dto.getCreatedAt(), dto.getCompletedAt());
     }
 }

--- a/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionEntryAssembler.java
+++ b/src/main/java/com/flab/coongyapay/transaction/assembler/TransactionEntryAssembler.java
@@ -1,0 +1,36 @@
+package com.flab.coongyapay.transaction.assembler;
+
+import com.flab.coongyapay.transaction.domain.TransactionEntry;
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TransactionEntryAssembler {
+
+    public TransactionEntryDto toDto(TransactionEntry domain) {
+        return new TransactionEntryDto(
+                domain.getId(),
+                domain.getTransactionId(),
+                domain.getWalletId(),
+                domain.getEntryType().name(),
+                domain.getAmount(),
+                domain.getBalanceAfter(),
+                domain.getWalletSequence(),
+                domain.getCreatedAt()
+        );
+    }
+
+    public TransactionEntry toDomain(TransactionEntryDto dto) {
+        return TransactionEntry.from(
+                dto.getId(),
+                dto.getTransactionId(),
+                dto.getWalletId(),
+                TransactionEntryType.valueOf(dto.getEntryType()),
+                dto.getAmount(),
+                dto.getBalanceAfter(),
+                dto.getWalletSequence(),
+                dto.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
+++ b/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
@@ -55,6 +55,15 @@ public class Transaction {
         return new Transaction(null, walletId, accountId, TransactionType.CHARGE, null, amount, TransactionStatus.CREATED, remark, null, null, null);
     }
 
+    /**
+     * 보상(환불) 거래 생성. 원거래(parentTransactionId)에 1:1로 매달리며,
+     * transaction 테이블의 UNIQUE(parent_transaction_id)가 이중 보상을 차단한다.
+     */
+    public static Transaction createCompensation(Long walletId, Long accountId, BigDecimal amount, Long parentTransactionId) {
+        return new Transaction(null, walletId, accountId, TransactionType.COMPENSATION, parentTransactionId, amount,
+                TransactionStatus.CREATED, null, null, null, null);
+    }
+
     public static Transaction from(Long id, Long walletId, Long accountId, TransactionType transactionType, Long parentTransactionId,
                                    BigDecimal amount, TransactionStatus status, String remark,
                                    TransactionFailureReason failureReason, LocalDateTime createdAt,

--- a/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
+++ b/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
@@ -19,6 +19,7 @@ public class Transaction {
 
     private final Long id;
     private final Long walletId;
+    private final Long accountId;
     private final TransactionType transactionType;
     private final Long parentTransactionId;
     private final BigDecimal amount;
@@ -28,9 +29,10 @@ public class Transaction {
     private final LocalDateTime createdAt;
     private final LocalDateTime completedAt;
 
-    private Transaction(Long id, Long walletId, TransactionType transactionType, Long parentTransactionId, BigDecimal amount, TransactionStatus status, String remark, TransactionFailureReason failureReason, LocalDateTime createdAt, LocalDateTime completedAt) {
+    private Transaction(Long id, Long walletId, Long accountId, TransactionType transactionType, Long parentTransactionId, BigDecimal amount, TransactionStatus status, String remark, TransactionFailureReason failureReason, LocalDateTime createdAt, LocalDateTime completedAt) {
         this.id = id;
         this.walletId = walletId;
+        this.accountId = accountId;
         this.transactionType = transactionType;
         this.parentTransactionId = parentTransactionId;
         this.amount = amount;
@@ -41,7 +43,7 @@ public class Transaction {
         this.completedAt = completedAt;
     }
 
-    public static Transaction createCharge(Long walletId, BigDecimal amount, String remark) {
+    public static Transaction createCharge(Long walletId, Long accountId, BigDecimal amount, String remark) {
         if (amount == null || amount.compareTo(MINIMUM_CHARGE_AMOUNT_LIMIT) < 0 || amount.compareTo(MAXIMUM_CHARGE_AMOUNT_LIMIT) > 0) {
             throw new BusinessException(ErrorCode.INVALID_CHARGE_AMOUNT);
         }
@@ -50,13 +52,17 @@ public class Transaction {
             throw new BusinessException(ErrorCode.INVALID_REMARK_LENGTH);
         }
 
-        return new Transaction(null, walletId, TransactionType.CHARGE, null, amount, TransactionStatus.CREATED, remark, null, null, null);
+        return new Transaction(null, walletId, accountId, TransactionType.CHARGE, null, amount, TransactionStatus.CREATED, remark, null, null, null);
     }
 
-    public static Transaction from(Long id, Long walletId, TransactionType transactionType, Long parentTransactionId,
+    public static Transaction from(Long id, Long walletId, Long accountId, TransactionType transactionType, Long parentTransactionId,
                                    BigDecimal amount, TransactionStatus status, String remark,
                                    TransactionFailureReason failureReason, LocalDateTime createdAt,
                                    LocalDateTime completedAt) {
-        return new Transaction(id, walletId, transactionType, parentTransactionId, amount, status, remark, failureReason, createdAt, completedAt);
+        return new Transaction(id, walletId, accountId, transactionType, parentTransactionId, amount, status, remark, failureReason, createdAt, completedAt);
+    }
+
+    public boolean isCharge() {
+        return transactionType == TransactionType.CHARGE;
     }
 }

--- a/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
+++ b/src/main/java/com/flab/coongyapay/transaction/domain/Transaction.java
@@ -1,8 +1,8 @@
-package com.flab.coongyapay.charge.domain;
+package com.flab.coongyapay.transaction.domain;
 
-import com.flab.coongyapay.charge.enums.TransactionFailureReason;
-import com.flab.coongyapay.charge.enums.TransactionStatus;
-import com.flab.coongyapay.charge.enums.TransactionType;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/com/flab/coongyapay/transaction/domain/TransactionEntry.java
+++ b/src/main/java/com/flab/coongyapay/transaction/domain/TransactionEntry.java
@@ -1,0 +1,48 @@
+package com.flab.coongyapay.transaction.domain;
+
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 지갑 원장(ledger) 항목. 잔액을 직접 UPDATE 하지 않고 CREDIT/DEBIT 항목을 append 하여
+ * 이력을 남긴다. (transaction_id, entry_type) UNIQUE로 이중 기입을 DB가 차단하고,
+ * (wallet_id, wallet_sequence) UNIQUE로 지갑별 순번 무결성을 보장한다.
+ */
+@Getter
+public class TransactionEntry {
+
+    private final Long id;
+    private final Long transactionId;
+    private final Long walletId;
+    private final TransactionEntryType entryType;
+    private final BigDecimal amount;
+    private final BigDecimal balanceAfter;
+    private final long walletSequence;
+    private final LocalDateTime createdAt;
+
+    private TransactionEntry(Long id, Long transactionId, Long walletId, TransactionEntryType entryType,
+                            BigDecimal amount, BigDecimal balanceAfter, long walletSequence, LocalDateTime createdAt) {
+        this.id = id;
+        this.transactionId = transactionId;
+        this.walletId = walletId;
+        this.entryType = entryType;
+        this.amount = amount;
+        this.balanceAfter = balanceAfter;
+        this.walletSequence = walletSequence;
+        this.createdAt = createdAt;
+    }
+
+    public static TransactionEntry credit(Long transactionId, Long walletId, BigDecimal amount,
+                                          BigDecimal balanceAfter, long walletSequence) {
+        return new TransactionEntry(null, transactionId, walletId, TransactionEntryType.CREDIT,
+                amount, balanceAfter, walletSequence, null);
+    }
+
+    public static TransactionEntry from(Long id, Long transactionId, Long walletId, TransactionEntryType entryType,
+                                        BigDecimal amount, BigDecimal balanceAfter, long walletSequence, LocalDateTime createdAt) {
+        return new TransactionEntry(id, transactionId, walletId, entryType, amount, balanceAfter, walletSequence, createdAt);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/transaction/enums/EntryType.java
+++ b/src/main/java/com/flab/coongyapay/transaction/enums/EntryType.java
@@ -1,4 +1,4 @@
-package com.flab.coongyapay.charge.enums;
+package com.flab.coongyapay.transaction.enums;
 
 public enum EntryType {
     CREDIT,

--- a/src/main/java/com/flab/coongyapay/transaction/enums/TransactionEntryType.java
+++ b/src/main/java/com/flab/coongyapay/transaction/enums/TransactionEntryType.java
@@ -1,6 +1,6 @@
 package com.flab.coongyapay.transaction.enums;
 
-public enum EntryType {
+public enum TransactionEntryType {
     CREDIT,
     DEBIT
 }

--- a/src/main/java/com/flab/coongyapay/transaction/enums/TransactionFailureReason.java
+++ b/src/main/java/com/flab/coongyapay/transaction/enums/TransactionFailureReason.java
@@ -1,4 +1,4 @@
-package com.flab.coongyapay.charge.enums;
+package com.flab.coongyapay.transaction.enums;
 
 public enum TransactionFailureReason {
     WITHDRAWAL_REJECTED,

--- a/src/main/java/com/flab/coongyapay/transaction/enums/TransactionStatus.java
+++ b/src/main/java/com/flab/coongyapay/transaction/enums/TransactionStatus.java
@@ -1,4 +1,4 @@
-package com.flab.coongyapay.charge.enums;
+package com.flab.coongyapay.transaction.enums;
 
 public enum TransactionStatus {
     CREATED,

--- a/src/main/java/com/flab/coongyapay/transaction/enums/TransactionType.java
+++ b/src/main/java/com/flab/coongyapay/transaction/enums/TransactionType.java
@@ -1,4 +1,4 @@
-package com.flab.coongyapay.charge.enums;
+package com.flab.coongyapay.transaction.enums;
 
 public enum TransactionType {
     CHARGE,

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionEntryMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionEntryMapper.java
@@ -1,0 +1,16 @@
+package com.flab.coongyapay.transaction.mapper;
+
+import com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+
+@Mapper
+public interface TransactionEntryMapper {
+
+    void insert(TransactionEntryDto dto);
+
+    Optional<TransactionEntryDto> findByTransactionIdAndEntryType(@Param("transactionId") Long transactionId,
+                                                                 @Param("entryType") String entryType);
+}

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -15,4 +15,6 @@ public interface TransactionMapper {
     Optional<TransactionDto> findById(@Param("id") Long id);
 
     BigDecimal sumInFlightChargeByWalletId(@Param("walletId") Long walletId);
+
+    Optional<TransactionDto> findChargeByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -21,6 +21,8 @@ public interface TransactionMapper {
 
     Optional<TransactionDto> findChargeByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
+    Optional<TransactionDto> findByParentTransactionId(@Param("parentTransactionId") Long parentTransactionId);
+
     // ===== 비동기 워커: 선점/펜싱/재시도 =====
 
     List<Long> selectClaimableIds(@Param("transactionType") String transactionType,

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -1,0 +1,15 @@
+package com.flab.coongyapay.transaction.mapper;
+
+import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+
+@Mapper
+public interface TransactionMapper {
+
+    void insert(TransactionDto dto);
+
+    Optional<TransactionDto> findById(@Param("id") Long id);
+}

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -1,5 +1,6 @@
 package com.flab.coongyapay.transaction.mapper;
 
+import com.flab.coongyapay.transaction.mapper.dto.RetryStateDto;
 import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -14,17 +15,43 @@ public interface TransactionMapper {
 
     void insert(TransactionDto dto);
 
-    List<Long> findProcessableChargeIds(@Param("limit") int limit);
-
     Optional<TransactionDto> findById(@Param("id") Long id);
 
     BigDecimal sumInFlightChargeByWalletId(@Param("walletId") Long walletId);
 
     Optional<TransactionDto> findChargeByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
+    // ===== 비동기 워커: 선점/펜싱/재시도 =====
+
+    List<Long> selectClaimableIds(@Param("transactionType") String transactionType,
+                                  @Param("statuses") List<String> statuses,
+                                  @Param("limit") int limit);
+
+    void acquireLease(@Param("id") Long id, @Param("leaseSeconds") int leaseSeconds);
+
+    long findLeaseToken(@Param("id") Long id);
+
     int updateStatus(@Param("id") Long id,
                      @Param("expectedStatus") String expectedStatus,
                      @Param("newStatus") String newStatus,
                      @Param("failureReason") String failureReason,
                      @Param("completedAt") LocalDateTime completedAt);
+
+    int updateStatusFenced(@Param("id") Long id,
+                           @Param("expectedStatus") String expectedStatus,
+                           @Param("newStatus") String newStatus,
+                           @Param("failureReason") String failureReason,
+                           @Param("completedAt") LocalDateTime completedAt,
+                           @Param("leaseToken") long leaseToken);
+
+    int scheduleRetry(@Param("id") Long id,
+                      @Param("backoffSeconds") int backoffSeconds,
+                      @Param("leaseToken") long leaseToken);
+
+    int incrementRequeryCount(@Param("id") Long id, @Param("leaseToken") long leaseToken);
+
+    RetryStateDto findRetryState(@Param("id") Long id);
+
+    void assignExternalIdempotencyKey(@Param("id") Long id,
+                                      @Param("externalIdempotencyKey") String externalIdempotencyKey);
 }

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -5,6 +5,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -12,9 +14,17 @@ public interface TransactionMapper {
 
     void insert(TransactionDto dto);
 
+    List<Long> findProcessableChargeIds(@Param("limit") int limit);
+
     Optional<TransactionDto> findById(@Param("id") Long id);
 
     BigDecimal sumInFlightChargeByWalletId(@Param("walletId") Long walletId);
 
     Optional<TransactionDto> findChargeByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
+
+    int updateStatus(@Param("id") Long id,
+                     @Param("expectedStatus") String expectedStatus,
+                     @Param("newStatus") String newStatus,
+                     @Param("failureReason") String failureReason,
+                     @Param("completedAt") LocalDateTime completedAt);
 }

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/TransactionMapper.java
@@ -4,6 +4,7 @@ import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Mapper
@@ -12,4 +13,6 @@ public interface TransactionMapper {
     void insert(TransactionDto dto);
 
     Optional<TransactionDto> findById(@Param("id") Long id);
+
+    BigDecimal sumInFlightChargeByWalletId(@Param("walletId") Long walletId);
 }

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/dto/RetryStateDto.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/dto/RetryStateDto.java
@@ -1,0 +1,23 @@
+package com.flab.coongyapay.transaction.mapper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 워커 재시도/대사 판정에 필요한 거래의 진행 상태 스냅샷.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RetryStateDto {
+    private int retryCount;
+    private int maxRetries;
+    private int requeryCount;
+    private LocalDateTime firstAttemptAt;
+    private String externalIdempotencyKey;
+}

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/dto/TransactionDto.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/dto/TransactionDto.java
@@ -1,0 +1,26 @@
+package com.flab.coongyapay.transaction.mapper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionDto {
+    private Long id;
+    private Long walletId;
+    private String transactionType;
+    private Long parentTransactionId;
+    private BigDecimal amount;
+    private String status;
+    private String remark;
+    private String failureReason;
+    private LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/com/flab/coongyapay/transaction/mapper/dto/TransactionEntryDto.java
+++ b/src/main/java/com/flab/coongyapay/transaction/mapper/dto/TransactionEntryDto.java
@@ -12,16 +12,13 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TransactionDto {
+public class TransactionEntryDto {
     private Long id;
+    private Long transactionId;
     private Long walletId;
-    private Long accountId;
-    private String transactionType;
-    private Long parentTransactionId;
+    private String entryType;
     private BigDecimal amount;
-    private String status;
-    private String remark;
-    private String failureReason;
+    private BigDecimal balanceAfter;
+    private long walletSequence;
     private LocalDateTime createdAt;
-    private LocalDateTime completedAt;
 }

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionEntryRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionEntryRepository.java
@@ -1,0 +1,35 @@
+package com.flab.coongyapay.transaction.repository;
+
+import com.flab.coongyapay.transaction.assembler.TransactionEntryAssembler;
+import com.flab.coongyapay.transaction.domain.TransactionEntry;
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import com.flab.coongyapay.transaction.mapper.TransactionEntryMapper;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TransactionEntryRepository {
+
+    private final TransactionEntryMapper transactionEntryMapper;
+    private final TransactionEntryAssembler transactionEntryAssembler;
+
+    public TransactionEntry save(TransactionEntry entry) {
+        TransactionEntryDto dto = transactionEntryAssembler.toDto(entry);
+        transactionEntryMapper.insert(dto);
+        return transactionEntryAssembler.toDomain(dto);
+    }
+
+    public Optional<TransactionEntry> findByTransactionIdAndEntryType(Long transactionId, TransactionEntryType entryType) {
+        return transactionEntryMapper.findByTransactionIdAndEntryType(transactionId, entryType.name())
+                .map(transactionEntryAssembler::toDomain);
+    }
+
+    public boolean existsCredit(Long transactionId) {
+        return transactionEntryMapper.findByTransactionIdAndEntryType(transactionId, TransactionEntryType.CREDIT.name())
+                .isPresent();
+    }
+}

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -1,0 +1,28 @@
+package com.flab.coongyapay.transaction.repository;
+
+import com.flab.coongyapay.transaction.assembler.TransactionAssembler;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.mapper.TransactionMapper;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TransactionRepository {
+
+    private final TransactionMapper transactionMapper;
+    private final TransactionAssembler transactionAssembler;
+
+    public Optional<Transaction> findById(Long id) {
+        return transactionMapper.findById(id).map(transactionAssembler::toDomain);
+    }
+
+    public Transaction save(Transaction transaction) {
+        TransactionDto transactionDto = transactionAssembler.toDto(transaction);
+        transactionMapper.insert(transactionDto);
+        return transactionAssembler.toDomain(transactionDto);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -31,4 +31,8 @@ public class TransactionRepository {
     public BigDecimal sumInFlightChargeByWalletId(Long walletId) {
         return transactionMapper.sumInFlightChargeByWalletId(walletId);
     }
+
+    public Optional<Transaction> findChargeByIdAndUserId(Long id, Long userId) {
+        return transactionMapper.findChargeByIdAndUserId(id, userId).map(transactionAssembler::toDomain);
+    }
 }

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -41,6 +41,10 @@ public class TransactionRepository {
         return transactionMapper.findChargeByIdAndUserId(id, userId).map(transactionAssembler::toDomain);
     }
 
+    public Optional<Transaction> findByParentTransactionId(Long parentTransactionId) {
+        return transactionMapper.findByParentTransactionId(parentTransactionId).map(transactionAssembler::toDomain);
+    }
+
     // ===== 비동기 워커: 선점/펜싱/재시도 =====
 
     public List<Long> selectClaimableIds(TransactionType type, List<TransactionStatus> statuses, int limit) {

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -5,8 +5,10 @@ import com.flab.coongyapay.transaction.domain.Transaction;
 import com.flab.coongyapay.transaction.mapper.TransactionMapper;
 import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Repository
@@ -24,5 +26,9 @@ public class TransactionRepository {
         TransactionDto transactionDto = transactionAssembler.toDto(transaction);
         transactionMapper.insert(transactionDto);
         return transactionAssembler.toDomain(transactionDto);
+    }
+
+    public BigDecimal sumInFlightChargeByWalletId(Long walletId) {
+        return transactionMapper.sumInFlightChargeByWalletId(walletId);
     }
 }

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -2,13 +2,16 @@ package com.flab.coongyapay.transaction.repository;
 
 import com.flab.coongyapay.transaction.assembler.TransactionAssembler;
 import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
 import com.flab.coongyapay.transaction.mapper.TransactionMapper;
 import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -32,7 +35,21 @@ public class TransactionRepository {
         return transactionMapper.sumInFlightChargeByWalletId(walletId);
     }
 
+    public List<Long> findProcessableChargeIds(int limit) {
+        return transactionMapper.findProcessableChargeIds(limit);
+    }
+
     public Optional<Transaction> findChargeByIdAndUserId(Long id, Long userId) {
         return transactionMapper.findChargeByIdAndUserId(id, userId).map(transactionAssembler::toDomain);
+    }
+
+    /**
+     * CAS 상태 전이. 기대 상태(expected)일 때만 next로 전이하며, 전이된 경우 true.
+     * 동시에 다른 워커/대사가 먼저 전이했다면 0행 → false.
+     */
+    public boolean updateStatus(Long id, TransactionStatus expected, TransactionStatus next,
+                                TransactionFailureReason failureReason, LocalDateTime completedAt) {
+        return transactionMapper.updateStatus(id, expected.name(), next.name(),
+                failureReason == null ? null : failureReason.name(), completedAt) == 1;
     }
 }

--- a/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/flab/coongyapay/transaction/repository/TransactionRepository.java
@@ -4,7 +4,9 @@ import com.flab.coongyapay.transaction.assembler.TransactionAssembler;
 import com.flab.coongyapay.transaction.domain.Transaction;
 import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
 import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
 import com.flab.coongyapay.transaction.mapper.TransactionMapper;
+import com.flab.coongyapay.transaction.mapper.dto.RetryStateDto;
 import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -35,21 +37,56 @@ public class TransactionRepository {
         return transactionMapper.sumInFlightChargeByWalletId(walletId);
     }
 
-    public List<Long> findProcessableChargeIds(int limit) {
-        return transactionMapper.findProcessableChargeIds(limit);
-    }
-
     public Optional<Transaction> findChargeByIdAndUserId(Long id, Long userId) {
         return transactionMapper.findChargeByIdAndUserId(id, userId).map(transactionAssembler::toDomain);
     }
 
+    // ===== 비동기 워커: 선점/펜싱/재시도 =====
+
+    public List<Long> selectClaimableIds(TransactionType type, List<TransactionStatus> statuses, int limit) {
+        List<String> statusNames = statuses.stream().map(Enum::name).toList();
+        return transactionMapper.selectClaimableIds(type.name(), statusNames, limit);
+    }
+
+    public void acquireLease(Long id, int leaseSeconds) {
+        transactionMapper.acquireLease(id, leaseSeconds);
+    }
+
+    public long findLeaseToken(Long id) {
+        return transactionMapper.findLeaseToken(id);
+    }
+
     /**
-     * CAS 상태 전이. 기대 상태(expected)일 때만 next로 전이하며, 전이된 경우 true.
-     * 동시에 다른 워커/대사가 먼저 전이했다면 0행 → false.
+     * CAS 상태 전이(비펜싱). 동기 단계/단일 워커 경로용.
      */
     public boolean updateStatus(Long id, TransactionStatus expected, TransactionStatus next,
                                 TransactionFailureReason failureReason, LocalDateTime completedAt) {
         return transactionMapper.updateStatus(id, expected.name(), next.name(),
                 failureReason == null ? null : failureReason.name(), completedAt) == 1;
+    }
+
+    /**
+     * 펜싱 CAS 전이. 선점한 lease_token일 때만 전이 → 재선점된 스테일 워커의 쓰기 차단.
+     */
+    public boolean updateStatusFenced(Long id, TransactionStatus expected, TransactionStatus next,
+                                      TransactionFailureReason failureReason, LocalDateTime completedAt, long leaseToken) {
+        return transactionMapper.updateStatusFenced(id, expected.name(), next.name(),
+                failureReason == null ? null : failureReason.name(), completedAt, leaseToken) == 1;
+    }
+
+    public boolean scheduleRetry(Long id, int backoffSeconds, long leaseToken) {
+        return transactionMapper.scheduleRetry(id, backoffSeconds, leaseToken) == 1;
+    }
+
+    public boolean incrementRequeryCount(Long id, long leaseToken) {
+        return transactionMapper.incrementRequeryCount(id, leaseToken) == 1;
+    }
+
+    public RetryStateDto findRetryState(Long id) {
+        return transactionMapper.findRetryState(id);
+    }
+
+    public void assignExternalIdempotencyKey(Long id, String externalIdempotencyKey) {
+        transactionMapper.assignExternalIdempotencyKey(id, externalIdempotencyKey);
     }
 }

--- a/src/main/java/com/flab/coongyapay/user/domain/UserTransferPin.java
+++ b/src/main/java/com/flab/coongyapay/user/domain/UserTransferPin.java
@@ -6,6 +6,9 @@ import java.time.LocalDateTime;
 
 @Getter
 public class UserTransferPin {
+    private static final int MAX_FAILED_TRANSFER_PIN_COUNT = 5;
+    public static final LocalDateTime PERMANENT_LOCK = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
     private final Long id;
     private final Long userId;
     private final String transferPinHash;
@@ -28,9 +31,20 @@ public class UserTransferPin {
         return new UserTransferPin(id, userId, transferPinHash, failedTransferPinCount, lockedUntil);
     }
 
-    //TODO 검증, 변경 메서드 추가하기
-    //increaseFailedCount()
-    //lockFor()
-    //unlock()
+    public boolean isLockedAt(LocalDateTime localDateTime) {
+        return lockedUntil != null && lockedUntil.isAfter(localDateTime);
+    }
+
+    public UserTransferPin incrementFailedTransferPinCount() {
+        int newFailedCount = failedTransferPinCount + 1;
+        LocalDateTime newLockedUntil = newFailedCount >= MAX_FAILED_TRANSFER_PIN_COUNT ? PERMANENT_LOCK : lockedUntil;
+        return from(id, userId, transferPinHash, newFailedCount, newLockedUntil);
+    }
+
+    public UserTransferPin resetFailedTransferPinCount() {
+        return from(id, userId, transferPinHash, 0, null);
+    }
+
+    //TODO 변경 메서드 추가하기
     //changeTransferPin()
 }

--- a/src/main/java/com/flab/coongyapay/user/mapper/UserTransferPinMapper.java
+++ b/src/main/java/com/flab/coongyapay/user/mapper/UserTransferPinMapper.java
@@ -3,8 +3,14 @@ package com.flab.coongyapay.user.mapper;
 import com.flab.coongyapay.user.mapper.dto.UserTransferPinDto;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Optional;
+
 @Mapper
 public interface UserTransferPinMapper {
 
     void insert(UserTransferPinDto userTransferPinDto);
+
+    Optional<UserTransferPinDto> findByUserIdForUpdate(Long userId);
+
+    int update(UserTransferPinDto userTransferPinDto);
 }

--- a/src/main/java/com/flab/coongyapay/user/repository/UserTransferPinRepository.java
+++ b/src/main/java/com/flab/coongyapay/user/repository/UserTransferPinRepository.java
@@ -7,6 +7,8 @@ import com.flab.coongyapay.user.mapper.dto.UserTransferPinDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class UserTransferPinRepository {
@@ -18,5 +20,15 @@ public class UserTransferPinRepository {
         UserTransferPinDto userTransferPinDto = userTransferPinAssembler.toDto(userTransferPin);
         userTransferPinMapper.insert(userTransferPinDto);
         return userTransferPinAssembler.toDomain(userTransferPinDto);
+    }
+
+    public Optional<UserTransferPin> findByUserIdForUpdate(Long userId) {
+        return userTransferPinMapper.findByUserIdForUpdate(userId)
+                .map(userTransferPinAssembler::toDomain);
+    }
+
+    public int update(UserTransferPin userTransferPin) {
+        UserTransferPinDto dto = userTransferPinAssembler.toDto(userTransferPin);
+        return userTransferPinMapper.update(dto);
     }
 }

--- a/src/main/java/com/flab/coongyapay/user/service/UserTransferPinVerifier.java
+++ b/src/main/java/com/flab/coongyapay/user/service/UserTransferPinVerifier.java
@@ -1,0 +1,50 @@
+package com.flab.coongyapay.user.service;
+
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.user.domain.UserTransferPin;
+import com.flab.coongyapay.user.repository.UserTransferPinRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserTransferPinVerifier {
+
+    private final UserTransferPinRepository userTransferPinRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 송금 비밀번호 검증 실패로 예외 발생해도 실패 카운트 및 잠금 UPDATE를 커밋하기 위해 noRollbackFor를 추가
+    @Transactional(noRollbackFor = BusinessException.class)
+    public void verify(Long userId, String rawPin) {
+        // 1. UserTransferPin 행 단위 비관적 락
+        UserTransferPin userTransferPin = userTransferPinRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+        // 2. 잠금 여부 확인
+        if (userTransferPin.isLockedAt(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.TRANSFER_PIN_LOCKED);
+        }
+
+        // 3. BCrypt 비교
+        //     - 실패 시 failedTransferPinCount 증가, 5회 도달 시 잠금
+        //     - 성공 시 failedTransferPinCount 리셋, lockedUntil 리셋
+        if (!passwordEncoder.matches(rawPin, userTransferPin.getTransferPinHash())) {
+            UserTransferPin incremented = userTransferPin.incrementFailedTransferPinCount();
+            userTransferPinRepository.update(incremented);
+
+            if (incremented.isLockedAt(LocalDateTime.now())) {
+                throw new BusinessException(ErrorCode.TRANSFER_PIN_LOCKED);
+            }
+
+            throw new BusinessException(ErrorCode.INVALID_TRANSFER_PIN);
+        }
+
+        UserTransferPin reset = userTransferPin.resetFailedTransferPinCount();
+        userTransferPinRepository.update(reset);
+    }
+}

--- a/src/main/java/com/flab/coongyapay/wallet/domain/Wallet.java
+++ b/src/main/java/com/flab/coongyapay/wallet/domain/Wallet.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 
 @Getter
 public class Wallet {
+    public static final BigDecimal MAXIMUM_BALANCE_LIMIT = BigDecimal.valueOf(2_000_000);
+
     private final Long id;
     private final Long userId;
     private final BigDecimal balance;
@@ -24,5 +26,9 @@ public class Wallet {
 
     public static Wallet from(Long id, Long userId, BigDecimal balance, long version) {
         return new Wallet(id, userId, balance, version);
+    }
+
+    public boolean isChargeableWithin(BigDecimal inFlight, BigDecimal amount) {
+        return balance.add(inFlight).add(amount).compareTo(MAXIMUM_BALANCE_LIMIT) <= 0;
     }
 }

--- a/src/main/java/com/flab/coongyapay/wallet/mapper/WalletMapper.java
+++ b/src/main/java/com/flab/coongyapay/wallet/mapper/WalletMapper.java
@@ -2,9 +2,16 @@ package com.flab.coongyapay.wallet.mapper;
 
 import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
 
 @Mapper
 public interface WalletMapper {
 
     void insert(WalletDto walletDto);
+
+    Optional<WalletDto> findByUserId(@Param("userId") Long userId);
+
+    Optional<WalletDto> findByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/main/java/com/flab/coongyapay/wallet/mapper/WalletMapper.java
+++ b/src/main/java/com/flab/coongyapay/wallet/mapper/WalletMapper.java
@@ -4,6 +4,7 @@ import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Mapper
@@ -14,4 +15,8 @@ public interface WalletMapper {
     Optional<WalletDto> findByUserId(@Param("userId") Long userId);
 
     Optional<WalletDto> findByUserIdForUpdate(@Param("userId") Long userId);
+
+    Optional<WalletDto> findByIdForUpdate(@Param("id") Long id);
+
+    void updateBalanceAndVersion(@Param("id") Long id, @Param("balance") BigDecimal balance, @Param("version") long version);
 }

--- a/src/main/java/com/flab/coongyapay/wallet/repository/WalletRepository.java
+++ b/src/main/java/com/flab/coongyapay/wallet/repository/WalletRepository.java
@@ -7,6 +7,7 @@ import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Repository
@@ -28,5 +29,13 @@ public class WalletRepository {
 
     public Optional<Wallet> findByUserIdForUpdate(Long userId) {
         return walletMapper.findByUserIdForUpdate(userId).map(walletAssembler::toDomain);
+    }
+
+    public Optional<Wallet> findByIdForUpdate(Long id) {
+        return walletMapper.findByIdForUpdate(id).map(walletAssembler::toDomain);
+    }
+
+    public void updateBalanceAndVersion(Long id, BigDecimal balance, long version) {
+        walletMapper.updateBalanceAndVersion(id, balance, version);
     }
 }

--- a/src/main/java/com/flab/coongyapay/wallet/repository/WalletRepository.java
+++ b/src/main/java/com/flab/coongyapay/wallet/repository/WalletRepository.java
@@ -7,6 +7,8 @@ import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class WalletRepository {
@@ -18,5 +20,13 @@ public class WalletRepository {
         WalletDto walletDto = walletAssembler.toDto(wallet);
         walletMapper.insert(walletDto);
         return walletAssembler.toDomain(walletDto);
+    }
+
+    public Optional<Wallet> findByUserId(Long userId) {
+        return walletMapper.findByUserId(userId).map(walletAssembler::toDomain);
+    }
+
+    public Optional<Wallet> findByUserIdForUpdate(Long userId) {
+        return walletMapper.findByUserIdForUpdate(userId).map(walletAssembler::toDomain);
     }
 }

--- a/src/main/resources/mapper/account/BankAccountMapper.xml
+++ b/src/main/resources/mapper/account/BankAccountMapper.xml
@@ -44,6 +44,13 @@
           AND deleted_at IS NULL
     </select>
 
+    <!-- 비동기 워커 출금용: account_id로 계좌를 조회한다(삭제 여부 무관 — 출금 참조 정보 확보). -->
+    <select id="findById" resultType="com.flab.coongyapay.account.mapper.dto.BankAccountDto">
+        SELECT id, user_id, bank_code, account_number, account_holder_name, registered_at, deleted_at
+        FROM bank_account
+        WHERE id = #{id}
+    </select>
+
     <update id="softDelete">
         UPDATE bank_account
            SET deleted_at = NOW()

--- a/src/main/resources/mapper/account/BankAccountMapper.xml
+++ b/src/main/resources/mapper/account/BankAccountMapper.xml
@@ -36,6 +36,14 @@
         ORDER BY registered_at DESC
     </select>
 
+    <select id="findActiveByIdAndUserId" resultType="com.flab.coongyapay.account.mapper.dto.BankAccountDto">
+        SELECT id, user_id, bank_code, account_number, account_holder_name, registered_at, deleted_at
+        FROM bank_account
+        WHERE id = #{id}
+          AND user_id = #{userId}
+          AND deleted_at IS NULL
+    </select>
+
     <update id="softDelete">
         UPDATE bank_account
            SET deleted_at = NOW()

--- a/src/main/resources/mapper/idempotency/IdempotencyMapper.xml
+++ b/src/main/resources/mapper/idempotency/IdempotencyMapper.xml
@@ -16,7 +16,6 @@
           AND idempotency_key = #{idempotencyKey}
     </select>
 
-
     <update id="reclaim">
         UPDATE idempotency_key
            SET lease_expires_at = DATE_ADD(NOW(), INTERVAL #{leaseSeconds} SECOND)

--- a/src/main/resources/mapper/idempotency/IdempotencyMapper.xml
+++ b/src/main/resources/mapper/idempotency/IdempotencyMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.coongyapay.idempotency.mapper.IdempotencyMapper">
+
+    <insert id="insert">
+        INSERT INTO idempotency_key (user_id, endpoint, idempotency_key, request_hash, status, response_http_status, response_body, lease_expires_at, expires_at)
+        VALUES (#{record.userId}, #{record.endpoint}, #{record.idempotencyKey}, #{record.requestHash}, #{record.status}, #{record.responseHttpStatus}, #{record.responseBody}, DATE_ADD(NOW(), INTERVAL #{leaseSeconds} SECOND), DATE_ADD(NOW(), INTERVAL #{ttlSeconds} SECOND))
+    </insert>
+
+    <select id="findByPk" resultType="com.flab.coongyapay.idempotency.mapper.dto.IdempotencyRecordDto">
+        SELECT user_id, endpoint, idempotency_key, request_hash, status, response_http_status, response_body, lease_expires_at, expires_at
+        FROM idempotency_key
+        WHERE user_id = #{userId}
+          AND endpoint = #{endpoint}
+          AND idempotency_key = #{idempotencyKey}
+    </select>
+
+
+    <update id="reclaim">
+        UPDATE idempotency_key
+           SET lease_expires_at = DATE_ADD(NOW(), INTERVAL #{leaseSeconds} SECOND)
+         WHERE user_id = #{userId}
+           AND endpoint = #{endpoint}
+           AND idempotency_key = #{idempotencyKey}
+           AND status = 'PROCESSING'
+           AND lease_expires_at &lt; NOW()
+    </update>
+
+    <update id="complete">
+        UPDATE idempotency_key
+           SET status = 'COMPLETED', response_http_status=#{responseHttpStatus}, response_body=#{responseBody}
+         WHERE user_id = #{userId}
+           AND endpoint = #{endpoint}
+           AND idempotency_key = #{idempotencyKey}
+           AND status = 'PROCESSING'
+    </update>
+
+    <delete id="delete">
+        DELETE FROM idempotency_key
+        WHERE user_id = #{userId}
+          AND endpoint = #{endpoint}
+          AND idempotency_key = #{idempotencyKey}
+          AND status = 'PROCESSING'
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/reconciliation/ReconciliationMapper.xml
+++ b/src/main/resources/mapper/reconciliation/ReconciliationMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.coongyapay.reconciliation.mapper.ReconciliationMapper">
+
+    <update id="expireIdleCreatedCharges">
+        UPDATE transaction
+           SET status = 'EXPIRED'
+         WHERE transaction_type = 'CHARGE'
+           AND status = 'CREATED'
+           AND created_at &lt;= DATE_SUB(NOW(), INTERVAL #{idleSeconds} SECOND)
+           AND (lease_expires_at IS NULL OR lease_expires_at &lt;= NOW())
+    </update>
+
+    <!-- wallet.balance == 마지막 원장 balance_after (원장 없으면 0) -->
+    <select id="countBalanceMismatches" resultType="int">
+        SELECT COUNT(*)
+        FROM wallet w
+        WHERE w.balance &lt;&gt; COALESCE(
+            (SELECT te.balance_after
+             FROM transaction_entry te
+             WHERE te.wallet_id = w.id
+             ORDER BY te.wallet_sequence DESC
+             LIMIT 1), 0)
+    </select>
+
+    <!-- wallet.version == MAX(wallet_sequence) == COUNT(entries) (순번 무결·무결점) -->
+    <select id="countVersionIntegrityViolations" resultType="int">
+        SELECT COUNT(*)
+        FROM wallet w
+        WHERE w.version &lt;&gt; COALESCE((SELECT MAX(te.wallet_sequence) FROM transaction_entry te WHERE te.wallet_id = w.id), 0)
+           OR COALESCE((SELECT MAX(te.wallet_sequence) FROM transaction_entry te WHERE te.wallet_id = w.id), 0)
+              &lt;&gt; (SELECT COUNT(*) FROM transaction_entry te WHERE te.wallet_id = w.id)
+    </select>
+
+    <!-- COMPLETED CHARGE ↔ 정확히 1개의 CREDIT 원장 -->
+    <select id="countCompletedChargesWithoutSingleCredit" resultType="int">
+        SELECT COUNT(*)
+        FROM transaction t
+        WHERE t.transaction_type = 'CHARGE'
+          AND t.status = 'COMPLETED'
+          AND (SELECT COUNT(*) FROM transaction_entry te
+               WHERE te.transaction_id = t.id AND te.entry_type = 'CREDIT') &lt;&gt; 1
+    </select>
+
+    <select id="countNonTerminalOlderThanMinutes" resultType="int">
+        SELECT COUNT(*)
+        FROM transaction
+        WHERE status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING','UNKNOWN','COMPENSATING','REFUNDING')
+          AND updated_at &lt;= DATE_SUB(NOW(), INTERVAL #{minutes} MINUTE)
+    </select>
+
+    <select id="countByStatus" resultType="int">
+        SELECT COUNT(*) FROM transaction WHERE status = #{status}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/transaction/TransactionEntryMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionEntryMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.coongyapay.transaction.mapper.TransactionEntryMapper">
+
+    <insert id="insert" parameterType="com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO transaction_entry (transaction_id, wallet_id, entry_type, amount, balance_after, wallet_sequence)
+        VALUES (#{transactionId}, #{walletId}, #{entryType}, #{amount}, #{balanceAfter}, #{walletSequence})
+    </insert>
+
+    <select id="findByTransactionIdAndEntryType" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto">
+        SELECT id, transaction_id, wallet_id, entry_type, amount, balance_after, wallet_sequence, created_at
+        FROM transaction_entry
+        WHERE transaction_id = #{transactionId}
+          AND entry_type = #{entryType}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -15,4 +15,11 @@
         VALUES (#{walletId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, #{completedAt})
     </insert>
 
+    <select id="sumInFlightChargeByWalletId" resultType="java.math.BigDecimal">
+        SELECT COALESCE(SUM(amount), 0)
+        FROM transaction
+        WHERE wallet_id = #{walletId}
+          AND transaction_type = 'CHARGE'
+          AND status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING','UNKNOWN','COMPENSATING')
+    </select>
 </mapper>

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -27,6 +27,12 @@
           AND status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING','UNKNOWN','COMPENSATING')
     </select>
 
+    <select id="findByParentTransactionId" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
+        SELECT <include refid="columns"/>
+        FROM transaction
+        WHERE parent_transaction_id = #{parentTransactionId}
+    </select>
+
     <select id="findChargeByIdAndUserId" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
         SELECT t.id, t.wallet_id, t.account_id, t.transaction_type, t.parent_transaction_id, t.amount, t.status, t.remark, t.failure_reason, t.created_at, t.completed_at
         FROM transaction t

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.coongyapay.transaction.mapper.TransactionMapper">
+
+    <select id="findById" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
+        SELECT id, wallet_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, created_at, completed_at
+        FROM transaction
+        WHERE id = #{id}
+    </select>
+
+    <insert id="insert" parameterType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO transaction (wallet_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, completed_at)
+        VALUES (#{walletId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, #{completedAt})
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -22,4 +22,14 @@
           AND transaction_type = 'CHARGE'
           AND status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING','UNKNOWN','COMPENSATING')
     </select>
+
+    <select id="findChargeByIdAndUserId" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
+        SELECT t.id, t.wallet_id, t.transaction_type, t.parent_transaction_id, t.amount, t.status, t.remark, t.failure_reason, t.created_at, t.completed_at
+        FROM transaction t
+        JOIN wallet w
+          ON t.wallet_id = w.id
+        WHERE t.id = #{id}
+          AND w.user_id = #{userId}
+          AND t.transaction_type = 'CHARGE'
+    </select>
 </mapper>

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -3,16 +3,20 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.flab.coongyapay.transaction.mapper.TransactionMapper">
 
+    <sql id="columns">
+        id, wallet_id, account_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, created_at, completed_at
+    </sql>
+
     <select id="findById" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
-        SELECT id, wallet_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, created_at, completed_at
+        SELECT <include refid="columns"/>
         FROM transaction
         WHERE id = #{id}
     </select>
 
     <insert id="insert" parameterType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto"
             useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO transaction (wallet_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, completed_at)
-        VALUES (#{walletId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, #{completedAt})
+        INSERT INTO transaction (wallet_id, account_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, completed_at)
+        VALUES (#{walletId}, #{accountId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, #{completedAt})
     </insert>
 
     <select id="sumInFlightChargeByWalletId" resultType="java.math.BigDecimal">
@@ -24,7 +28,7 @@
     </select>
 
     <select id="findChargeByIdAndUserId" resultType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto">
-        SELECT t.id, t.wallet_id, t.transaction_type, t.parent_transaction_id, t.amount, t.status, t.remark, t.failure_reason, t.created_at, t.completed_at
+        SELECT t.id, t.wallet_id, t.account_id, t.transaction_type, t.parent_transaction_id, t.amount, t.status, t.remark, t.failure_reason, t.created_at, t.completed_at
         FROM transaction t
         JOIN wallet w
           ON t.wallet_id = w.id
@@ -32,4 +36,25 @@
           AND w.user_id = #{userId}
           AND t.transaction_type = 'CHARGE'
     </select>
+
+    <!-- 비동기 워커 폴링: 진행 가능한 CHARGE 거래 id. (3B에서 lease/SKIP LOCKED로 강화) -->
+    <select id="findProcessableChargeIds" resultType="long">
+        SELECT id
+        FROM transaction
+        WHERE transaction_type = 'CHARGE'
+          AND status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING')
+        ORDER BY id
+        LIMIT #{limit}
+    </select>
+
+    <!-- CAS 상태 전이: 기대 상태일 때만 전이(낙관적 동시성). completed_at은 종료 전이에서만 세팅 -->
+    <update id="updateStatus">
+        UPDATE transaction
+           SET status = #{newStatus},
+               failure_reason = #{failureReason},
+               completed_at = #{completedAt}
+         WHERE id = #{id}
+           AND status = #{expectedStatus}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/transaction/TransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/TransactionMapper.xml
@@ -15,8 +15,8 @@
 
     <insert id="insert" parameterType="com.flab.coongyapay.transaction.mapper.dto.TransactionDto"
             useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO transaction (wallet_id, account_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, completed_at)
-        VALUES (#{walletId}, #{accountId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, #{completedAt})
+        INSERT INTO transaction (wallet_id, account_id, transaction_type, parent_transaction_id, amount, status, remark, failure_reason, next_retry_at, completed_at)
+        VALUES (#{walletId}, #{accountId}, #{transactionType}, #{parentTransactionId}, #{amount}, #{status}, #{remark}, #{failureReason}, NOW(), #{completedAt})
     </insert>
 
     <select id="sumInFlightChargeByWalletId" resultType="java.math.BigDecimal">
@@ -37,17 +37,40 @@
           AND t.transaction_type = 'CHARGE'
     </select>
 
-    <!-- 비동기 워커 폴링: 진행 가능한 CHARGE 거래 id. (3B에서 lease/SKIP LOCKED로 강화) -->
-    <select id="findProcessableChargeIds" resultType="long">
+    <!-- ===== 비동기 워커: 짧게 선점 → 락 밖에서 작업 → 짧게 기록 ===== -->
+
+    <!--
+      클레임 대상: 진행 가능한(non-terminal actionable) 거래.
+      next_retry_at 도래 & lease 만료(또는 없음)인 행만. FOR UPDATE SKIP LOCKED로 워커 간 경합 회피.
+      transactionType 파라미터로 CHARGE/COMPENSATION 워커를 분리 운용.
+    -->
+    <select id="selectClaimableIds" resultType="long">
         SELECT id
         FROM transaction
-        WHERE transaction_type = 'CHARGE'
-          AND status IN ('CREATED','WITHDRAWING','WITHDRAWN','DEPOSITING')
+        WHERE transaction_type = #{transactionType}
+          AND status IN
+          <foreach item="s" collection="statuses" open="(" separator="," close=")">#{s}</foreach>
+          AND (next_retry_at IS NULL OR next_retry_at &lt;= NOW())
+          AND (lease_expires_at IS NULL OR lease_expires_at &lt;= NOW())
         ORDER BY id
         LIMIT #{limit}
+        FOR UPDATE SKIP LOCKED
     </select>
 
-    <!-- CAS 상태 전이: 기대 상태일 때만 전이(낙관적 동시성). completed_at은 종료 전이에서만 세팅 -->
+    <!-- lease 획득: 만료시각 갱신 + fencing 토큰 증가(단조). first_attempt_at 최초 1회 기록. -->
+    <update id="acquireLease">
+        UPDATE transaction
+           SET lease_expires_at = DATE_ADD(NOW(), INTERVAL #{leaseSeconds} SECOND),
+               lease_token = lease_token + 1,
+               first_attempt_at = COALESCE(first_attempt_at, NOW())
+         WHERE id = #{id}
+    </update>
+
+    <select id="findLeaseToken" resultType="long">
+        SELECT lease_token FROM transaction WHERE id = #{id}
+    </select>
+
+    <!-- CAS 상태 전이(기대 상태일 때만). completed_at은 종료 전이에서만 세팅. -->
     <update id="updateStatus">
         UPDATE transaction
            SET status = #{newStatus},
@@ -55,6 +78,49 @@
                completed_at = #{completedAt}
          WHERE id = #{id}
            AND status = #{expectedStatus}
+    </update>
+
+    <!-- 펜싱 CAS 전이: 내가 선점한 lease_token일 때만 기록 → 리스 만료 후 재선점된 스테일 워커의 쓰기 차단. -->
+    <update id="updateStatusFenced">
+        UPDATE transaction
+           SET status = #{newStatus},
+               failure_reason = #{failureReason},
+               completed_at = #{completedAt}
+         WHERE id = #{id}
+           AND status = #{expectedStatus}
+           AND lease_token = #{leaseToken}
+    </update>
+
+    <!-- 재시도 백오프 예약: next_retry_at 갱신 + retry_count 증가. lease는 해제(다음 선점 허용). -->
+    <update id="scheduleRetry">
+        UPDATE transaction
+           SET next_retry_at = DATE_ADD(NOW(), INTERVAL #{backoffSeconds} SECOND),
+               retry_count = retry_count + 1,
+               lease_expires_at = NULL
+         WHERE id = #{id}
+           AND lease_token = #{leaseToken}
+    </update>
+
+    <!-- 재조회 카운트 증가(UNKNOWN 재조회 상한 판정용). -->
+    <update id="incrementRequeryCount">
+        UPDATE transaction
+           SET requery_count = requery_count + 1
+         WHERE id = #{id}
+           AND lease_token = #{leaseToken}
+    </update>
+
+    <select id="findRetryState" resultType="com.flab.coongyapay.transaction.mapper.dto.RetryStateDto">
+        SELECT retry_count, max_retries, requery_count,
+               first_attempt_at AS firstAttemptAt, external_idempotency_key AS externalIdempotencyKey
+        FROM transaction
+        WHERE id = #{id}
+    </select>
+
+    <!-- 출금 write-ahead 의도 시 외부 멱등키 확정(최초 1회). -->
+    <update id="assignExternalIdempotencyKey">
+        UPDATE transaction
+           SET external_idempotency_key = COALESCE(external_idempotency_key, #{externalIdempotencyKey})
+         WHERE id = #{id}
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/user/UserTransferPinMapper.xml
+++ b/src/main/resources/mapper/user/UserTransferPinMapper.xml
@@ -9,4 +9,16 @@
         VALUES (#{userId}, #{transferPin}, #{failedTransferPinCount}, #{lockedUntil})
     </insert>
 
+    <select id="findByUserIdForUpdate" resultType="com.flab.coongyapay.user.mapper.dto.UserTransferPinDto">
+        SELECT id, user_id, transfer_pin, failed_transfer_pin_count, locked_until
+        FROM user_transfer_pin
+        WHERE user_id = #{userId}
+        FOR UPDATE
+    </select>
+
+    <update id="update">
+        UPDATE user_transfer_pin
+           SET failed_transfer_pin_count = #{failedTransferPinCount}, locked_until = #{lockedUntil}
+         WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/wallet/WalletMapper.xml
+++ b/src/main/resources/mapper/wallet/WalletMapper.xml
@@ -9,4 +9,17 @@
         VALUES (#{userId}, #{balance}, #{version})
     </insert>
 
+    <select id="findByUserId" resultType="com.flab.coongyapay.wallet.mapper.dto.WalletDto">
+        SELECT id, user_id, balance, version
+        FROM wallet
+        WHERE user_id = #{userId}
+    </select>
+
+    <select id="findByUserIdForUpdate" resultType="com.flab.coongyapay.wallet.mapper.dto.WalletDto">
+        SELECT id, user_id, balance, version
+        FROM wallet
+        WHERE user_id = #{userId}
+        FOR UPDATE
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/wallet/WalletMapper.xml
+++ b/src/main/resources/mapper/wallet/WalletMapper.xml
@@ -22,4 +22,19 @@
         FOR UPDATE
     </select>
 
+    <select id="findByIdForUpdate" resultType="com.flab.coongyapay.wallet.mapper.dto.WalletDto">
+        SELECT id, user_id, balance, version
+        FROM wallet
+        WHERE id = #{id}
+        FOR UPDATE
+    </select>
+
+    <!-- wallet FOR UPDATE 락 보유 상태에서만 호출. version은 순번 로그 인덱스(낙관적 아님). -->
+    <update id="updateBalanceAndVersion">
+        UPDATE wallet
+           SET balance = #{balance},
+               version = #{version}
+         WHERE id = #{id}
+    </update>
+
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -131,3 +131,21 @@ CREATE TABLE IF NOT EXISTS `transaction_entry` (
 ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4
     COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `idempotency_key` (
+    `user_id`              INT          NOT NULL,
+    `endpoint`             VARCHAR(100) NOT NULL,
+    `idempotency_key`      VARCHAR(36)  NOT NULL,
+    `request_hash`         VARCHAR(64)  NOT NULL COMMENT '민감정보 제외 본문의 SHA-256 hex',
+    `status`               VARCHAR(20)  NOT NULL COMMENT 'PROCESSING,COMPLETED',
+    `response_http_status` INT          NULL,
+    `response_body`        TEXT         NULL,
+    `lease_expires_at`     DATETIME     NOT NULL COMMENT 'PROCESSING 점유 만료 시각(선점 시 now+120초)',
+    `expires_at`           DATETIME     NOT NULL COMMENT '보관 TTL(now+24시간), 정리 스케줄러 대상 판별',
+    `created_at`           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`user_id`, `endpoint`, `idempotency_key`),
+    INDEX `idx_idempotency_key_expires_at` (`expires_at`)
+) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -14,8 +14,8 @@ CREATE TABLE IF NOT EXISTS `user` (
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_user_email` (`email`)
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_0900_ai_ci;
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE TABLE IF NOT EXISTS `user_password` (
     `id`                 INT          NOT NULL AUTO_INCREMENT,
@@ -28,8 +28,8 @@ CREATE TABLE IF NOT EXISTS `user_password` (
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_user_password_user_id` (`user_id`)
 ) ENGINE = InnoDB
-DEFAULT CHARSET = utf8mb4
-COLLATE = utf8mb4_0900_ai_ci;
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE TABLE IF NOT EXISTS `wallet` (
     `id`         INT           NOT NULL AUTO_INCREMENT,
@@ -41,8 +41,8 @@ CREATE TABLE IF NOT EXISTS `wallet` (
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_wallet_user_id` (`user_id`)
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_0900_ai_ci;
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE TABLE IF NOT EXISTS `user_transfer_pin` (
     `id`                        INT          NOT NULL AUTO_INCREMENT,
@@ -55,8 +55,8 @@ CREATE TABLE IF NOT EXISTS `user_transfer_pin` (
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_user_transfer_pin_user_id` (`user_id`)
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_0900_ai_ci;
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE TABLE IF NOT EXISTS `user_login_history` (
     `id`	                INT	         NOT NULL AUTO_INCREMENT,
@@ -83,6 +83,51 @@ CREATE TABLE IF NOT EXISTS `bank_account` (
     PRIMARY KEY (`id`),
     INDEX idx_bank_account_user_id (`user_id`),
     UNIQUE KEY uk_active_bank_account (`user_id`, `bank_code`, `account_number`, `active_flag`)
+) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `transaction` (
+    `id`                     BIGINT        NOT NULL AUTO_INCREMENT,
+    `wallet_id`              INT           NOT NULL,
+    `transaction_type`       VARCHAR(20)   NOT NULL COMMENT 'CHARGE,WITHDRAW,TRANSFER,COMPENSATION',
+    `parent_transaction_id`  BIGINT        NULL COMMENT 'COMPENSATION 거래의 원거래 ID',
+    `amount`                 DECIMAL(15,0) NOT NULL,
+    `status`                 VARCHAR(20)   NOT NULL,
+    `remark`                 VARCHAR(255)  NULL,
+    `failure_reason`         VARCHAR(40)   NULL,
+    `external_idempotency_key` VARCHAR(100) NULL COMMENT '은행 전송용 멱등키',
+    `lease_token`            BIGINT        NOT NULL DEFAULT 0 COMMENT 'fencing 카운터',
+    `lease_expires_at`       DATETIME      NULL,
+    `next_retry_at`          DATETIME      NULL,
+    `retry_count`            INT           NOT NULL DEFAULT 0,
+    `max_retries`            INT           NOT NULL DEFAULT 3,
+    `requery_count`          INT           NOT NULL DEFAULT 0 COMMENT 'UNKNOWN 재조회 횟수',
+    `first_attempt_at`       DATETIME      NULL,
+    `created_at`             DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`             DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `completed_at`           DATETIME      NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_compensation_parent` (`parent_transaction_id`),
+    INDEX `idx_tx_wallet_id` (`wallet_id`),
+    INDEX `idx_tx_claim` (`status`, `next_retry_at`)
+) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `transaction_entry` (
+    `id`              BIGINT        NOT NULL AUTO_INCREMENT,
+    `transaction_id`  BIGINT        NOT NULL,
+    `wallet_id`       INT           NOT NULL,
+    `entry_type`      VARCHAR(20)   NOT NULL COMMENT 'CREDIT,DEBIT',
+    `amount`          DECIMAL(15,0) NOT NULL,
+    `balance_after`   DECIMAL(15,0) NOT NULL,
+    `wallet_sequence` BIGINT        NOT NULL,
+    `created_at`      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_entry_tx_type` (`transaction_id`, `entry_type`),
+    UNIQUE KEY `uk_entry_wallet_seq` (`wallet_id`, `wallet_sequence`),
+    INDEX `idx_entry_wallet` (`wallet_id`)
 ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4
     COLLATE = utf8mb4_0900_ai_ci;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS `bank_account` (
 CREATE TABLE IF NOT EXISTS `transaction` (
     `id`                     BIGINT        NOT NULL AUTO_INCREMENT,
     `wallet_id`              INT           NOT NULL,
+    `account_id`             INT           NULL COMMENT 'CHARGE 출금 대상 은행계좌(비동기 워커 출금용), COMPENSATION은 NULL',
     `transaction_type`       VARCHAR(20)   NOT NULL COMMENT 'CHARGE,WITHDRAW,TRANSFER,COMPENSATION',
     `parent_transaction_id`  BIGINT        NULL COMMENT 'COMPENSATION 거래의 원거래 ID',
     `amount`                 DECIMAL(15,0) NOT NULL,

--- a/src/test/java/com/flab/coongyapay/account/mapper/BankAccountMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/account/mapper/BankAccountMapperTest.java
@@ -1,0 +1,134 @@
+package com.flab.coongyapay.account.mapper;
+
+import com.flab.coongyapay.account.mapper.dto.BankAccountDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@MybatisTest
+class BankAccountMapperTest {
+
+    @Autowired
+    private BankAccountMapper bankAccountMapper;
+
+    @Test
+    void insert시_id_자동채번() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        Assertions.assertThat(bankAccountDto.getId()).isNotNull();
+    }
+
+    @Test
+    void countActiveByUserId_사용자별_계좌수_반환() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        int count = bankAccountMapper.countActiveByUserId(getDto().getUserId());
+
+        Assertions.assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void existsActiveByUserIdAndAccount_사용자_계좌_존재여부_반환() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        boolean exists = bankAccountMapper.existsActiveByUserIdAndAccount(bankAccountDto.getUserId(), bankAccountDto.getBankCode(), bankAccountDto.getAccountNumber());
+
+        Assertions.assertThat(exists).isTrue();
+    }
+
+    @Test
+    void findActiveByUserId_사용자_활성계좌_반환() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        List<BankAccountDto> activeByUserId = bankAccountMapper.findActiveByUserId(getDto().getUserId());
+
+        Assertions.assertThat(activeByUserId).hasSize(1);
+        Assertions.assertThat(activeByUserId.get(0).getUserId()).isEqualTo(bankAccountDto.getUserId());
+        Assertions.assertThat(activeByUserId.get(0).getBankCode()).isEqualTo(bankAccountDto.getBankCode());
+        Assertions.assertThat(activeByUserId.get(0).getAccountNumber()).isEqualTo(bankAccountDto.getAccountNumber());
+        Assertions.assertThat(activeByUserId.get(0).getAccountHolderName()).isEqualTo(bankAccountDto.getAccountHolderName());
+    }
+
+    @Test
+    void findActiveByUserId_사용자_비활성계좌_반환_안_함() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+        int deleted = bankAccountMapper.softDelete(bankAccountDto.getId(), bankAccountDto.getUserId());
+
+        List<BankAccountDto> activeByUserId = bankAccountMapper.findActiveByUserId(getDto().getUserId());
+
+        Assertions.assertThat(deleted).isEqualTo(1);
+        Assertions.assertThat(activeByUserId).hasSize(0);
+    }
+
+    @Test
+    void findActiveByIdAndUserId_사용자_소유_활성계좌_반환() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        Optional<BankAccountDto> optional = bankAccountMapper.findActiveByIdAndUserId(bankAccountDto.getId(), getDto().getUserId());
+
+        Assertions.assertThat(optional.isPresent()).isTrue();
+        Assertions.assertThat(optional.get().getUserId()).isEqualTo(bankAccountDto.getUserId());
+        Assertions.assertThat(optional.get().getBankCode()).isEqualTo(bankAccountDto.getBankCode());
+        Assertions.assertThat(optional.get().getAccountNumber()).isEqualTo(bankAccountDto.getAccountNumber());
+        Assertions.assertThat(optional.get().getAccountHolderName()).isEqualTo(bankAccountDto.getAccountHolderName());
+    }
+
+    @Test
+    void findActiveByIdAndUserId_다른_사용자_소유_계좌_반환_안_함() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+
+        Optional<BankAccountDto> optional = bankAccountMapper.findActiveByIdAndUserId(bankAccountDto.getId(), 2L);
+
+        Assertions.assertThat(optional.isPresent()).isFalse();
+    }
+
+    @Test
+    void findActiveByIdAndUserId_본인_소유_비활성계좌_반환_안_함() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+        int deleted = bankAccountMapper.softDelete(bankAccountDto.getId(), bankAccountDto.getUserId());
+
+        Optional<BankAccountDto> optional = bankAccountMapper.findActiveByIdAndUserId(bankAccountDto.getId(), bankAccountDto.getUserId());
+
+        Assertions.assertThat(deleted).isEqualTo(1);
+        Assertions.assertThat(optional.isPresent()).isFalse();
+    }
+
+    @Test
+    void softDelete_삭제_후_재등록_가능() {
+        BankAccountDto bankAccountDto = getDto();
+        bankAccountMapper.insert(bankAccountDto);
+        int deleted = bankAccountMapper.softDelete(bankAccountDto.getId(), bankAccountDto.getUserId());
+
+        bankAccountMapper.insert(bankAccountDto);
+        Optional<BankAccountDto> optional = bankAccountMapper.findActiveByIdAndUserId(bankAccountDto.getId(), bankAccountDto.getUserId());
+
+        Assertions.assertThat(deleted).isEqualTo(1);
+        Assertions.assertThat(optional.isPresent()).isTrue();
+        Assertions.assertThat(optional.get().getUserId()).isEqualTo(bankAccountDto.getUserId());
+        Assertions.assertThat(optional.get().getBankCode()).isEqualTo(bankAccountDto.getBankCode());
+        Assertions.assertThat(optional.get().getAccountNumber()).isEqualTo(bankAccountDto.getAccountNumber());
+        Assertions.assertThat(optional.get().getAccountHolderName()).isEqualTo(bankAccountDto.getAccountHolderName());
+    }
+
+    private static BankAccountDto getDto() {
+        BankAccountDto bankAccountDto = new BankAccountDto();
+        bankAccountDto.setUserId(1L);
+        bankAccountDto.setBankCode("bankCode");
+        bankAccountDto.setAccountNumber("111122223333");
+        bankAccountDto.setAccountHolderName("김쿵야");
+        return bankAccountDto;
+    }
+
+}

--- a/src/test/java/com/flab/coongyapay/charge/domain/TransactionTest.java
+++ b/src/test/java/com/flab/coongyapay/charge/domain/TransactionTest.java
@@ -1,0 +1,55 @@
+package com.flab.coongyapay.charge.domain;
+
+import com.flab.coongyapay.charge.enums.TransactionStatus;
+import com.flab.coongyapay.charge.enums.TransactionType;
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+class TransactionTest {
+
+    @Test
+    void createCharge_성공하면_CREATED_1원() {
+        Transaction chargeTransaction = Transaction.createCharge(1L, BigDecimal.ONE, "김쿵야");
+        Assertions.assertThat(chargeTransaction.getStatus()).isSameAs(TransactionStatus.CREATED);
+        Assertions.assertThat(chargeTransaction.getTransactionType()).isSameAs(TransactionType.CHARGE);
+        Assertions.assertThat(chargeTransaction.getRemark()).isEqualTo("김쿵야");
+        Assertions.assertThat(chargeTransaction.getAmount()).isEqualTo(BigDecimal.ONE);
+    }
+
+    @Test
+    void createCharge_성공하면_CREATED_2백만원() {
+        Transaction chargeTransaction = Transaction.createCharge(1L, BigDecimal.valueOf(2_000_000), "김쿵야");
+        Assertions.assertThat(chargeTransaction.getStatus()).isSameAs(TransactionStatus.CREATED);
+        Assertions.assertThat(chargeTransaction.getTransactionType()).isSameAs(TransactionType.CHARGE);
+        Assertions.assertThat(chargeTransaction.getRemark()).isEqualTo("김쿵야");
+        Assertions.assertThat(chargeTransaction.getAmount()).isEqualTo(BigDecimal.valueOf(2_000_000));
+    }
+
+    @Test
+    void createCharge_금액_1원_미만이면_INVALID_CHARGE_AMOUNT_던짐() {
+        Assertions.assertThatThrownBy(() -> {
+            Transaction.createCharge(1L, BigDecimal.ZERO, "김쿵야");
+        }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CHARGE_AMOUNT);
+    }
+
+    @Test
+    void createCharge_금액_2백만원_초과면_INVALID_CHARGE_AMOUNT_던짐() {
+        Assertions.assertThatThrownBy(() -> {
+            Transaction.createCharge(1L, BigDecimal.valueOf(2_000_001), "김쿵야");
+        }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CHARGE_AMOUNT);
+    }
+
+    @Test
+    void createCharge_remark_길이_7자_초과면_INVALID_REMARK_LENGTH_던짐() {
+        Assertions.assertThatThrownBy(() -> {
+            Transaction.createCharge(1L, BigDecimal.ONE, "일이삼사오육칠팔");
+        }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REMARK_LENGTH);
+    }
+}

--- a/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorFailureIntegrationTest.java
+++ b/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorFailureIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.bank.BankMaintenancePolicy;
+import com.flab.coongyapay.bank.BankWithdrawalStatus;
+import com.flab.coongyapay.bank.StubBankClient;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@Transactional
+class ChargeProcessorFailureIntegrationTest {
+
+    @Autowired private ChargeProcessor chargeProcessor;
+    @Autowired private ChargeClaimService chargeClaimService;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private BankAccountRepository bankAccountRepository;
+    @Autowired private TransactionRepository transactionRepository;
+    @Autowired private StubBankClient stubBankClient;
+
+    // 자정(점검시간) 실행 시 flaky 방지: 기본 false, 점검 테스트만 true로 스텁
+    @MockitoBean private BankMaintenancePolicy bankMaintenancePolicy;
+
+    @BeforeEach
+    void setUp() {
+        when(bankMaintenancePolicy.isMaintenanceTime()).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        stubBankClient.reset();
+    }
+
+    @Test
+    void 은행이_출금_거절하면_FAILED_WITHDRAWAL_REJECTED() {
+        stubBankClient.setWithdrawScenario(StubBankClient.WithdrawScenario.REJECT);
+        Long id = createdChargeId(BigDecimal.valueOf(10_000), "1112223330001");
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token);
+
+        Transaction tx = transactionRepository.findById(id).orElseThrow();
+        Assertions.assertThat(tx.getStatus()).isSameAs(TransactionStatus.FAILED);
+        Assertions.assertThat(tx.getFailureReason()).isSameAs(TransactionFailureReason.WITHDRAWAL_REJECTED);
+    }
+
+    @Test
+    void 출금_결과_불명이면_UNKNOWN() {
+        stubBankClient.setWithdrawScenario(StubBankClient.WithdrawScenario.UNCLEAR);
+        Long id = createdChargeId(BigDecimal.valueOf(10_000), "1112223330002");
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token);
+
+        Assertions.assertThat(transactionRepository.findById(id).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.UNKNOWN);
+    }
+
+    @Test
+    void UNKNOWN_대사에서_출금확인되면_크레딧까지_완료() {
+        stubBankClient.setWithdrawScenario(StubBankClient.WithdrawScenario.UNCLEAR);
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223330003", "김쿵야"));
+        BigDecimal amount = BigDecimal.valueOf(40_000);
+        Long id = transactionRepository.save(Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야")).getId();
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token); // → UNKNOWN
+
+        // 대사: 은행이 "출금됨" 응답 → 재개
+        stubBankClient.setWithdrawalStatus(BankWithdrawalStatus.WITHDRAWN);
+        chargeProcessor.process(id, token);
+
+        Assertions.assertThat(transactionRepository.findById(id).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.COMPLETED);
+        Assertions.assertThat(walletRepository.findByUserId(userId).orElseThrow().getBalance())
+                .isEqualByComparingTo(amount);
+    }
+
+    @Test
+    void UNKNOWN_대사에서_미출금_freshness이내면_재출금_의도로_전이() {
+        stubBankClient.setWithdrawScenario(StubBankClient.WithdrawScenario.UNCLEAR);
+        Long id = createdChargeId(BigDecimal.valueOf(10_000), "1112223330004");
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token); // → UNKNOWN
+
+        stubBankClient.setWithdrawalStatus(BankWithdrawalStatus.NOT_WITHDRAWN);
+        chargeProcessor.process(id, token);
+
+        Assertions.assertThat(transactionRepository.findById(id).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.WITHDRAWING);
+    }
+
+    @Test
+    void UNKNOWN_대사가_계속_불명이면_재조회_상한_초과시_NEEDS_REVIEW() {
+        stubBankClient.setWithdrawScenario(StubBankClient.WithdrawScenario.UNCLEAR);
+        Long id = createdChargeId(BigDecimal.valueOf(10_000), "1112223330005");
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token); // → UNKNOWN
+
+        stubBankClient.setWithdrawalStatus(BankWithdrawalStatus.UNKNOWN);
+        for (int i = 0; i < 5; i++) {
+            chargeProcessor.process(id, token); // 재조회 5회 → 상한 초과
+        }
+
+        Assertions.assertThat(transactionRepository.findById(id).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.NEEDS_REVIEW);
+    }
+
+    @Test
+    void 실행시점_점검시간이면_출금없이_FAILED_BANK_MAINTENANCE() {
+        when(bankMaintenancePolicy.isMaintenanceTime()).thenReturn(true);
+        Long id = createdChargeId(BigDecimal.valueOf(10_000), "1112223330006");
+
+        long token = claimLeaseToken(id);
+        chargeProcessor.process(id, token);
+
+        Transaction tx = transactionRepository.findById(id).orElseThrow();
+        Assertions.assertThat(tx.getStatus()).isSameAs(TransactionStatus.FAILED);
+        Assertions.assertThat(tx.getFailureReason()).isSameAs(TransactionFailureReason.BANK_MAINTENANCE);
+    }
+
+    private Long createdChargeId(BigDecimal amount, String accountNumber) {
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", accountNumber, "김쿵야"));
+        return transactionRepository.save(Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야")).getId();
+    }
+
+    private long claimLeaseToken(Long transactionId) {
+        return chargeClaimService.claimBatch(50, 30).stream()
+                .filter(c -> c.id().equals(transactionId))
+                .findFirst().orElseThrow().leaseToken();
+    }
+
+    private Long uniqueUserId() {
+        return System.nanoTime() % 1_000_000_000L;
+    }
+}

--- a/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorIntegrationTest.java
+++ b/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorIntegrationTest.java
@@ -20,20 +20,19 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 // @Transactional: 커밋된 데이터가 공유 Testcontainer를 오염시켜 @MybatisTest와 충돌하는 것을 방지(테스트 후 롤백).
-// (워커의 다중 커밋 내구성 검증은 3B에서 별도 정리 전략으로 다룬다)
 @SpringBootTest
 @Transactional
 class ChargeProcessorIntegrationTest {
 
     @Autowired private ChargeProcessor chargeProcessor;
+    @Autowired private ChargeClaimService chargeClaimService;
     @Autowired private WalletRepository walletRepository;
     @Autowired private BankAccountRepository bankAccountRepository;
     @Autowired private TransactionRepository transactionRepository;
     @Autowired private TransactionEntryRepository transactionEntryRepository;
 
     @Test
-    void 해피패스_처리하면_잔액이_증가하고_COMPLETED된다() {
-        // given: 잔액 0 지갑 + 계좌 + CREATED 충전 5만원
+    void 선점_후_처리하면_잔액이_증가하고_COMPLETED된다() {
         Long userId = uniqueUserId();
         Wallet wallet = walletRepository.save(Wallet.create(userId));
         BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223334445", "김쿵야"));
@@ -41,31 +40,28 @@ class ChargeProcessorIntegrationTest {
         Transaction created = transactionRepository.save(
                 Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야"));
 
-        // when
-        chargeProcessor.process(created.getId());
+        // when: 선점(lease) 후 처리
+        long leaseToken = claimLeaseToken(created.getId());
+        chargeProcessor.process(created.getId(), leaseToken);
 
-        // then: 거래 COMPLETED
+        // then
         Transaction processed = transactionRepository.findById(created.getId()).orElseThrow();
         Assertions.assertThat(processed.getStatus()).isSameAs(TransactionStatus.COMPLETED);
         Assertions.assertThat(processed.getCompletedAt()).isNotNull();
 
-        // 잔액 실제 증가 + version = 1
         Wallet after = walletRepository.findByUserId(userId).orElseThrow();
         Assertions.assertThat(after.getBalance()).isEqualByComparingTo(amount);
         Assertions.assertThat(after.getVersion()).isEqualTo(1L);
 
-        // 원장 CREDIT 1행, balance_after/순번 일치
         Optional<TransactionEntry> entry = transactionEntryRepository
                 .findByTransactionIdAndEntryType(created.getId(), TransactionEntryType.CREDIT);
         Assertions.assertThat(entry).isPresent();
-        Assertions.assertThat(entry.get().getAmount()).isEqualByComparingTo(amount);
         Assertions.assertThat(entry.get().getBalanceAfter()).isEqualByComparingTo(amount);
         Assertions.assertThat(entry.get().getWalletSequence()).isEqualTo(1L);
     }
 
     @Test
     void 두_번_처리해도_이중_입금되지_않는다() {
-        // given
         Long userId = uniqueUserId();
         Wallet wallet = walletRepository.save(Wallet.create(userId));
         BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223334446", "김쿵야"));
@@ -73,17 +69,55 @@ class ChargeProcessorIntegrationTest {
         Transaction created = transactionRepository.save(
                 Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야"));
 
-        // when: 재처리(멱등)
-        chargeProcessor.process(created.getId());
-        chargeProcessor.process(created.getId());
+        long leaseToken = claimLeaseToken(created.getId());
+        chargeProcessor.process(created.getId(), leaseToken);
+        chargeProcessor.process(created.getId(), leaseToken);
 
-        // then: 잔액은 한 번만 증가
         Wallet after = walletRepository.findByUserId(userId).orElseThrow();
         Assertions.assertThat(after.getBalance()).isEqualByComparingTo(amount);
         Assertions.assertThat(after.getVersion()).isEqualTo(1L);
     }
 
-    // user_id UNIQUE 충돌을 피하기 위해 나노초 기반 유니크 id (테스트 간 격리)
+    @Test
+    void 리스가_재선점되면_스테일_leaseToken_처리는_펜싱된다() {
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223334447", "김쿵야"));
+        BigDecimal amount = BigDecimal.valueOf(20_000);
+        Transaction created = transactionRepository.save(
+                Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야"));
+
+        // 워커 A가 선점 → staleToken
+        long staleToken = claimLeaseToken(created.getId());
+        // 리스 만료 후 워커 B가 재선점 → lease_token 증가
+        transactionRepository.acquireLease(created.getId(), 30);
+        long freshToken = transactionRepository.findLeaseToken(created.getId());
+        Assertions.assertThat(freshToken).isGreaterThan(staleToken);
+
+        // 스테일 토큰으로 처리 시도 → 펜싱되어 아무 것도 전이/입금되지 않음
+        chargeProcessor.process(created.getId(), staleToken);
+
+        Transaction stillCreated = transactionRepository.findById(created.getId()).orElseThrow();
+        Assertions.assertThat(stillCreated.getStatus()).isSameAs(TransactionStatus.CREATED);
+        Assertions.assertThat(walletRepository.findByUserId(userId).orElseThrow().getBalance())
+                .isEqualByComparingTo(BigDecimal.ZERO);
+
+        // 최신 토큰으로 처리하면 정상 완료
+        chargeProcessor.process(created.getId(), freshToken);
+        Assertions.assertThat(transactionRepository.findById(created.getId()).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.COMPLETED);
+        Assertions.assertThat(walletRepository.findByUserId(userId).orElseThrow().getBalance())
+                .isEqualByComparingTo(amount);
+    }
+
+    private long claimLeaseToken(Long transactionId) {
+        return chargeClaimService.claimBatch(50, 30).stream()
+                .filter(c -> c.id().equals(transactionId))
+                .findFirst()
+                .orElseThrow()
+                .leaseToken();
+    }
+
     private Long uniqueUserId() {
         return System.nanoTime() % 1_000_000_000L;
     }

--- a/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorIntegrationTest.java
+++ b/src/test/java/com/flab/coongyapay/charge/worker/ChargeProcessorIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.domain.TransactionEntry;
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.repository.TransactionEntryRepository;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+// @Transactional: 커밋된 데이터가 공유 Testcontainer를 오염시켜 @MybatisTest와 충돌하는 것을 방지(테스트 후 롤백).
+// (워커의 다중 커밋 내구성 검증은 3B에서 별도 정리 전략으로 다룬다)
+@SpringBootTest
+@Transactional
+class ChargeProcessorIntegrationTest {
+
+    @Autowired private ChargeProcessor chargeProcessor;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private BankAccountRepository bankAccountRepository;
+    @Autowired private TransactionRepository transactionRepository;
+    @Autowired private TransactionEntryRepository transactionEntryRepository;
+
+    @Test
+    void 해피패스_처리하면_잔액이_증가하고_COMPLETED된다() {
+        // given: 잔액 0 지갑 + 계좌 + CREATED 충전 5만원
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223334445", "김쿵야"));
+        BigDecimal amount = BigDecimal.valueOf(50_000);
+        Transaction created = transactionRepository.save(
+                Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야"));
+
+        // when
+        chargeProcessor.process(created.getId());
+
+        // then: 거래 COMPLETED
+        Transaction processed = transactionRepository.findById(created.getId()).orElseThrow();
+        Assertions.assertThat(processed.getStatus()).isSameAs(TransactionStatus.COMPLETED);
+        Assertions.assertThat(processed.getCompletedAt()).isNotNull();
+
+        // 잔액 실제 증가 + version = 1
+        Wallet after = walletRepository.findByUserId(userId).orElseThrow();
+        Assertions.assertThat(after.getBalance()).isEqualByComparingTo(amount);
+        Assertions.assertThat(after.getVersion()).isEqualTo(1L);
+
+        // 원장 CREDIT 1행, balance_after/순번 일치
+        Optional<TransactionEntry> entry = transactionEntryRepository
+                .findByTransactionIdAndEntryType(created.getId(), TransactionEntryType.CREDIT);
+        Assertions.assertThat(entry).isPresent();
+        Assertions.assertThat(entry.get().getAmount()).isEqualByComparingTo(amount);
+        Assertions.assertThat(entry.get().getBalanceAfter()).isEqualByComparingTo(amount);
+        Assertions.assertThat(entry.get().getWalletSequence()).isEqualTo(1L);
+    }
+
+    @Test
+    void 두_번_처리해도_이중_입금되지_않는다() {
+        // given
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "1112223334446", "김쿵야"));
+        BigDecimal amount = BigDecimal.valueOf(30_000);
+        Transaction created = transactionRepository.save(
+                Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야"));
+
+        // when: 재처리(멱등)
+        chargeProcessor.process(created.getId());
+        chargeProcessor.process(created.getId());
+
+        // then: 잔액은 한 번만 증가
+        Wallet after = walletRepository.findByUserId(userId).orElseThrow();
+        Assertions.assertThat(after.getBalance()).isEqualByComparingTo(amount);
+        Assertions.assertThat(after.getVersion()).isEqualTo(1L);
+    }
+
+    // user_id UNIQUE 충돌을 피하기 위해 나노초 기반 유니크 id (테스트 간 격리)
+    private Long uniqueUserId() {
+        return System.nanoTime() % 1_000_000_000L;
+    }
+}

--- a/src/test/java/com/flab/coongyapay/charge/worker/CompensationSagaIntegrationTest.java
+++ b/src/test/java/com/flab/coongyapay/charge/worker/CompensationSagaIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.flab.coongyapay.charge.worker;
+
+import com.flab.coongyapay.account.domain.BankAccount;
+import com.flab.coongyapay.account.repository.BankAccountRepository;
+import com.flab.coongyapay.bank.BankMaintenancePolicy;
+import com.flab.coongyapay.transaction.domain.Transaction;
+import com.flab.coongyapay.transaction.enums.TransactionFailureReason;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.repository.TransactionEntryRepository;
+import com.flab.coongyapay.transaction.repository.TransactionRepository;
+import com.flab.coongyapay.wallet.domain.Wallet;
+import com.flab.coongyapay.wallet.repository.WalletRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * 보상 사가는 다중 물리 트랜잭션에 걸쳐 있어 @Transactional(롤백) 방식이 부적합하다.
+ * (내부 credit의 @Transactional 예외가 공유 트랜잭션을 rollback-only로 오염) → 비트랜잭션 + 수동 정리.
+ */
+@SpringBootTest
+class CompensationSagaIntegrationTest {
+
+    private static final BigDecimal MAX_BALANCE = BigDecimal.valueOf(2_000_000);
+
+    @Autowired private ChargeProcessor chargeProcessor;
+    @Autowired private ChargeClaimService chargeClaimService;
+    @Autowired private CompensationProcessor compensationProcessor;
+    @Autowired private CompensationClaimService compensationClaimService;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private BankAccountRepository bankAccountRepository;
+    @Autowired private TransactionRepository transactionRepository;
+    @Autowired private TransactionEntryRepository transactionEntryRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean private BankMaintenancePolicy bankMaintenancePolicy;
+
+    @BeforeEach
+    void setUp() {
+        when(bankMaintenancePolicy.isMaintenanceTime()).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 비트랜잭션 커밋 데이터 정리(공유 Testcontainer 오염 방지). FK 제약 없음 → 순서 무관.
+        jdbcTemplate.execute("DELETE FROM transaction_entry");
+        jdbcTemplate.execute("DELETE FROM transaction");
+        jdbcTemplate.execute("DELETE FROM bank_account");
+        jdbcTemplate.execute("DELETE FROM wallet");
+    }
+
+    @Test
+    void 크레딧_한도초과_영구실패면_보상거래로_환불되고_부모는_FAILED_REFUNDED() {
+        // given: 잔액이 이미 한도(2,000,000)인 지갑 + CREATED 충전 10,000 (크레딧 시점 한도 초과 유발)
+        Long userId = uniqueUserId();
+        Wallet wallet = walletRepository.save(Wallet.create(userId));
+        walletRepository.updateBalanceAndVersion(wallet.getId(), MAX_BALANCE, 0);
+        BankAccount account = bankAccountRepository.save(BankAccount.create(userId, "088", "2223334440001", "김쿵야"));
+        BigDecimal amount = BigDecimal.valueOf(10_000);
+        Long chargeId = transactionRepository.save(
+                Transaction.createCharge(wallet.getId(), account.getId(), amount, "쿵야")).getId();
+
+        // when 1: 충전 처리 → 출금 성공 → 크레딧 한도초과 → 보상 개시
+        chargeProcessor.process(chargeId, claimCharge(chargeId));
+
+        // then 1: 부모 COMPENSATING, 자식 보상거래 생성, 잔액 불변, CREDIT 없음
+        Assertions.assertThat(transactionRepository.findById(chargeId).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.COMPENSATING);
+        Transaction compensation = transactionRepository.findByParentTransactionId(chargeId).orElseThrow();
+        Assertions.assertThat(compensation.getTransactionType()).isSameAs(TransactionType.COMPENSATION);
+        Assertions.assertThat(compensation.getStatus()).isSameAs(TransactionStatus.CREATED);
+        Assertions.assertThat(compensation.getAmount()).isEqualByComparingTo(amount);
+        Assertions.assertThat(transactionEntryRepository.existsCredit(chargeId)).isFalse();
+        Assertions.assertThat(walletRepository.findByUserId(userId).orElseThrow().getBalance())
+                .isEqualByComparingTo(MAX_BALANCE);
+
+        // when 2: 보상 처리 → 환불 성공 → COMPLETED → 부모 FAILED(REFUNDED)
+        compensationProcessor.process(compensation.getId(), claimCompensation(compensation.getId()));
+
+        // then 2
+        Assertions.assertThat(transactionRepository.findById(compensation.getId()).orElseThrow().getStatus())
+                .isSameAs(TransactionStatus.COMPLETED);
+        Transaction parent = transactionRepository.findById(chargeId).orElseThrow();
+        Assertions.assertThat(parent.getStatus()).isSameAs(TransactionStatus.FAILED);
+        Assertions.assertThat(parent.getFailureReason()).isSameAs(TransactionFailureReason.REFUNDED);
+        // 환불이므로 지갑 잔액은 여전히 불변
+        Assertions.assertThat(walletRepository.findByUserId(userId).orElseThrow().getBalance())
+                .isEqualByComparingTo(MAX_BALANCE);
+    }
+
+    private long claimCharge(Long id) {
+        return chargeClaimService.claimBatch(50, 30).stream()
+                .filter(c -> c.id().equals(id)).findFirst().orElseThrow().leaseToken();
+    }
+
+    private long claimCompensation(Long id) {
+        return compensationClaimService.claimBatch(50, 30).stream()
+                .filter(c -> c.id().equals(id)).findFirst().orElseThrow().leaseToken();
+    }
+
+    private Long uniqueUserId() {
+        return System.nanoTime() % 1_000_000_000L;
+    }
+}

--- a/src/test/java/com/flab/coongyapay/common/util/RequestHashUtilTest.java
+++ b/src/test/java/com/flab/coongyapay/common/util/RequestHashUtilTest.java
@@ -1,0 +1,24 @@
+package com.flab.coongyapay.common.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.security.NoSuchAlgorithmException;
+
+
+class RequestHashUtilTest {
+
+    @Test
+    void sha256HexTest_abc() {
+        String sha256Hex = RequestHashUtil.sha256Hex("abc");
+
+        Assertions.assertThat(sha256Hex).isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    }
+
+    @Test
+    void sha256HexTest_빈_문자열() {
+        String sha256Hex = RequestHashUtil.sha256Hex("");
+
+        Assertions.assertThat(sha256Hex).isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+}

--- a/src/test/java/com/flab/coongyapay/idempotency/mapper/IdempotencyMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/idempotency/mapper/IdempotencyMapperTest.java
@@ -1,0 +1,58 @@
+package com.flab.coongyapay.idempotency.mapper;
+
+import com.flab.coongyapay.idempotency.mapper.dto.IdempotencyRecordDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.util.Optional;
+
+
+@MybatisTest
+class IdempotencyMapperTest {
+
+    private static final String ENDPOINT = "POST /api/v1/charges";
+    private static final long LEASE_SECONDS = 120;
+    private static final long EXPIRED_LEASE_SECONDS = -120;
+    private static final long TTL_SECONDS = 86_400;
+
+    @Autowired
+    private IdempotencyMapper idempotencyMapper;
+
+    @Test
+    void 같은_PK로_두번_insert시_DuplicateKeyException() {
+        idempotencyMapper.insert(newDto("key"), LEASE_SECONDS, TTL_SECONDS);
+        Assertions.assertThatThrownBy(() -> {
+            idempotencyMapper.insert(newDto("key"), LEASE_SECONDS, TTL_SECONDS);
+        }).isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    void lease_만료된_PROCESSING만_reclaim_성공() {
+        idempotencyMapper.insert(newDto("key"), EXPIRED_LEASE_SECONDS, TTL_SECONDS);
+
+        int first = idempotencyMapper.reclaim(1L, ENDPOINT, "key", LEASE_SECONDS);
+        Assertions.assertThat(first).isEqualTo(1);
+
+        int second = idempotencyMapper.reclaim(1L, ENDPOINT, "key", LEASE_SECONDS);
+        Assertions.assertThat(second).isEqualTo(0);
+    }
+
+    @Test
+    void complete시_COMPLETED() {
+        idempotencyMapper.insert(newDto("key"), LEASE_SECONDS, TTL_SECONDS);
+        int affected = idempotencyMapper.complete(1L, ENDPOINT, "key", 202, "body");
+        Optional<IdempotencyRecordDto> optional = idempotencyMapper.findByPk(1L, ENDPOINT, "key");
+        Assertions.assertThat(affected).isSameAs(1);
+        Assertions.assertThat(optional).isPresent();
+        Assertions.assertThat(optional.get().getStatus()).isEqualTo("COMPLETED");
+        Assertions.assertThat(optional.get().getResponseHttpStatus()).isEqualTo(202);
+        Assertions.assertThat(optional.get().getResponseBody()).isEqualTo("body");
+    }
+
+    private IdempotencyRecordDto newDto(String key) {
+        return new IdempotencyRecordDto(1L, ENDPOINT, key, "hash", "PROCESSING", null, null, null, null);
+    }
+}

--- a/src/test/java/com/flab/coongyapay/idempotency/service/IdempotencyServiceTest.java
+++ b/src/test/java/com/flab/coongyapay/idempotency/service/IdempotencyServiceTest.java
@@ -1,0 +1,101 @@
+package com.flab.coongyapay.idempotency.service;
+
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.idempotency.domain.IdempotencyRecord;
+import com.flab.coongyapay.idempotency.enums.IdempotencyStatus;
+import com.flab.coongyapay.idempotency.repository.IdempotencyRepository;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class IdempotencyServiceTest {
+
+    private static final String ENDPOINT = "POST /api/v1/charges";
+    private static final String KEY = "key";
+    private static final String HASH = "hash1";
+    public static final String RESPONSE_BODY = "{\"chargeId\":1}";
+
+    @InjectMocks
+    private IdempotencyService idempotencyService;
+    @Mock
+    private IdempotencyRepository idempotencyRepository;
+
+    @Test
+    void 신규키면_newRequest_반환() {
+        when(idempotencyRepository.tryInsertProcessing(any())).thenReturn(true);
+
+        ClaimResult result = idempotencyService.claim(1L, ENDPOINT, KEY, HASH);
+
+        Assertions.assertThat(result.isReplayed()).isFalse();
+        verify(idempotencyRepository, never()).findByPk(any(), any(), any());
+        verify(idempotencyRepository, never()).reclaim(any(), any(), any());
+    }
+
+    @Test
+    void 해시_다르면_IDEMPOTENCY_KEY_CONFLICT_던짐() {
+        when(idempotencyRepository.tryInsertProcessing(any())).thenReturn(false);
+        when(idempotencyRepository.findByPk(1L, ENDPOINT, KEY))
+                .thenReturn(Optional.of(record("hash2", IdempotencyStatus.PROCESSING, null, null)));
+
+        Assertions.assertThatThrownBy(() -> idempotencyService.claim(1L, ENDPOINT, KEY, HASH))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.IDEMPOTENCY_KEY_CONFLICT);
+
+        verify(idempotencyRepository, never()).reclaim(any(), any(), any());
+    }
+
+    @Test
+    void 완료된_키면_캐시응답반환() {
+        when(idempotencyRepository.tryInsertProcessing(any())).thenReturn(false);
+        when(idempotencyRepository.findByPk(1L, ENDPOINT, KEY)).thenReturn(Optional.of(record(HASH, IdempotencyStatus.COMPLETED, HttpStatus.SC_ACCEPTED, RESPONSE_BODY)));
+
+        ClaimResult result = idempotencyService.claim(1L, ENDPOINT, KEY, HASH);
+
+        Assertions.assertThat(result.isReplayed()).isTrue();
+        Assertions.assertThat(result.getResponseHttpStatus()).isEqualTo(HttpStatus.SC_ACCEPTED);
+        Assertions.assertThat(result.getCachedResponseBody()).isEqualTo(RESPONSE_BODY);
+    }
+
+    @Test
+    void 처리중_키_reclaim_성공시_newRequest_반환() {
+        when(idempotencyRepository.tryInsertProcessing(any())).thenReturn(false);
+        when(idempotencyRepository.findByPk(1L, ENDPOINT, KEY)).thenReturn(Optional.of(record(HASH, IdempotencyStatus.PROCESSING, null, null)));
+        when(idempotencyRepository.reclaim(1L, ENDPOINT, KEY)).thenReturn(true);
+
+        ClaimResult result = idempotencyService.claim(1L, ENDPOINT, KEY, HASH);
+
+        Assertions.assertThat(result.isReplayed()).isFalse();
+        Assertions.assertThat(result.getResponseHttpStatus()).isNull();
+        Assertions.assertThat(result.getCachedResponseBody()).isNull();
+    }
+
+    @Test
+    void 처리중_키_reclaim_실패시_IDEMPOTENCY_KEY_PROCESSING_던짐() {
+        when(idempotencyRepository.tryInsertProcessing(any())).thenReturn(false);
+        when(idempotencyRepository.findByPk(1L, ENDPOINT, KEY)).thenReturn(Optional.of(record(HASH, IdempotencyStatus.PROCESSING, null, null)));
+        when(idempotencyRepository.reclaim(1L, ENDPOINT, KEY)).thenReturn(false);
+
+        Assertions.assertThatThrownBy(() -> {
+            idempotencyService.claim(1L, ENDPOINT, KEY, HASH);
+        })
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.IDEMPOTENCY_KEY_PROCESSING);
+    }
+
+    private IdempotencyRecord record(String hash, IdempotencyStatus status, Integer responseHttpStatus, String responseBody) {
+        return IdempotencyRecord.from(1L, ENDPOINT, KEY, hash, status, responseHttpStatus, responseBody);
+    }
+
+}

--- a/src/test/java/com/flab/coongyapay/reconciliation/mapper/ReconciliationMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/reconciliation/mapper/ReconciliationMapperTest.java
@@ -1,0 +1,82 @@
+package com.flab.coongyapay.reconciliation.mapper;
+
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.mapper.TransactionEntryMapper;
+import com.flab.coongyapay.transaction.mapper.TransactionMapper;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto;
+import com.flab.coongyapay.wallet.mapper.WalletMapper;
+import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+
+@MybatisTest
+class ReconciliationMapperTest {
+
+    @Autowired private ReconciliationMapper reconciliationMapper;
+    @Autowired private TransactionMapper transactionMapper;
+    @Autowired private TransactionEntryMapper transactionEntryMapper;
+    @Autowired private WalletMapper walletMapper;
+
+    @Test
+    void expireIdleCreatedCharges_유휴_CREATED만_EXPIRED() {
+        TransactionDto created = chargeDto(TransactionStatus.CREATED);
+        transactionMapper.insert(created);
+        TransactionDto withdrawing = chargeDto(TransactionStatus.CREATED);
+        transactionMapper.insert(withdrawing);
+        transactionMapper.updateStatus(withdrawing.getId(), TransactionStatus.CREATED.name(),
+                TransactionStatus.WITHDRAWING.name(), null, null);
+
+        int expired = reconciliationMapper.expireIdleCreatedCharges(0);
+
+        Assertions.assertThat(expired).isGreaterThanOrEqualTo(1);
+        Assertions.assertThat(transactionMapper.findById(created.getId()).orElseThrow().getStatus())
+                .isEqualTo(TransactionStatus.EXPIRED.name());
+        // WITHDRAWING은 만료되지 않음(출금 위험)
+        Assertions.assertThat(transactionMapper.findById(withdrawing.getId()).orElseThrow().getStatus())
+                .isEqualTo(TransactionStatus.WITHDRAWING.name());
+    }
+
+    @Test
+    void countCompletedChargesWithoutSingleCredit_CREDIT없는_COMPLETED충전_탐지() {
+        int before = reconciliationMapper.countCompletedChargesWithoutSingleCredit();
+
+        TransactionDto completed = chargeDto(TransactionStatus.COMPLETED);
+        transactionMapper.insert(completed);
+
+        // CREDIT 원장 없음 → 위반 +1
+        Assertions.assertThat(reconciliationMapper.countCompletedChargesWithoutSingleCredit() - before)
+                .isEqualTo(1);
+
+        // CREDIT 1개 추가 → 위반 해소
+        transactionEntryMapper.insert(new TransactionEntryDto(null, completed.getId(), 1L,
+                TransactionEntryType.CREDIT.name(), BigDecimal.ONE, BigDecimal.ONE, 1L, null));
+        Assertions.assertThat(reconciliationMapper.countCompletedChargesWithoutSingleCredit() - before)
+                .isEqualTo(0);
+    }
+
+    @Test
+    void countBalanceMismatches_원장없이_잔액이_0아니면_불일치() {
+        int before = reconciliationMapper.countBalanceMismatches();
+
+        // 원장이 없는데 잔액 100 → 마지막 balance_after(=0)와 불일치
+        walletMapper.insert(new WalletDto(null, uniqueUserId(), BigDecimal.valueOf(100), 0));
+
+        Assertions.assertThat(reconciliationMapper.countBalanceMismatches() - before).isEqualTo(1);
+    }
+
+    private TransactionDto chargeDto(TransactionStatus status) {
+        return new TransactionDto(null, 1L, 1L, TransactionType.CHARGE.name(), null,
+                BigDecimal.ONE, status.name(), "쿵야", null, null, null);
+    }
+
+    private Long uniqueUserId() {
+        return System.nanoTime() % 1_000_000_000L;
+    }
+}

--- a/src/test/java/com/flab/coongyapay/transaction/domain/TransactionTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/domain/TransactionTest.java
@@ -13,7 +13,7 @@ class TransactionTest {
 
     @Test
     void createCharge_성공하면_CREATED_1원() {
-        Transaction chargeTransaction = Transaction.createCharge(1L, BigDecimal.ONE, "김쿵야");
+        Transaction chargeTransaction = Transaction.createCharge(1L, 1L, BigDecimal.ONE, "김쿵야");
         Assertions.assertThat(chargeTransaction.getStatus()).isSameAs(TransactionStatus.CREATED);
         Assertions.assertThat(chargeTransaction.getTransactionType()).isSameAs(TransactionType.CHARGE);
         Assertions.assertThat(chargeTransaction.getRemark()).isEqualTo("김쿵야");
@@ -22,7 +22,7 @@ class TransactionTest {
 
     @Test
     void createCharge_성공하면_CREATED_2백만원() {
-        Transaction chargeTransaction = Transaction.createCharge(1L, BigDecimal.valueOf(2_000_000), "김쿵야");
+        Transaction chargeTransaction = Transaction.createCharge(1L, 1L, BigDecimal.valueOf(2_000_000), "김쿵야");
         Assertions.assertThat(chargeTransaction.getStatus()).isSameAs(TransactionStatus.CREATED);
         Assertions.assertThat(chargeTransaction.getTransactionType()).isSameAs(TransactionType.CHARGE);
         Assertions.assertThat(chargeTransaction.getRemark()).isEqualTo("김쿵야");
@@ -32,7 +32,7 @@ class TransactionTest {
     @Test
     void createCharge_금액_1원_미만이면_INVALID_CHARGE_AMOUNT_던짐() {
         Assertions.assertThatThrownBy(() -> {
-            Transaction.createCharge(1L, BigDecimal.ZERO, "김쿵야");
+            Transaction.createCharge(1L, 1L, BigDecimal.ZERO, "김쿵야");
         }).isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CHARGE_AMOUNT);
     }
@@ -40,7 +40,7 @@ class TransactionTest {
     @Test
     void createCharge_금액_2백만원_초과면_INVALID_CHARGE_AMOUNT_던짐() {
         Assertions.assertThatThrownBy(() -> {
-            Transaction.createCharge(1L, BigDecimal.valueOf(2_000_001), "김쿵야");
+            Transaction.createCharge(1L, 1L, BigDecimal.valueOf(2_000_001), "김쿵야");
         }).isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CHARGE_AMOUNT);
     }
@@ -48,7 +48,7 @@ class TransactionTest {
     @Test
     void createCharge_remark_길이_7자_초과면_INVALID_REMARK_LENGTH_던짐() {
         Assertions.assertThatThrownBy(() -> {
-            Transaction.createCharge(1L, BigDecimal.ONE, "일이삼사오육칠팔");
+            Transaction.createCharge(1L, 1L, BigDecimal.ONE, "일이삼사오육칠팔");
         }).isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REMARK_LENGTH);
     }

--- a/src/test/java/com/flab/coongyapay/transaction/domain/TransactionTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/domain/TransactionTest.java
@@ -1,7 +1,7 @@
-package com.flab.coongyapay.charge.domain;
+package com.flab.coongyapay.transaction.domain;
 
-import com.flab.coongyapay.charge.enums.TransactionStatus;
-import com.flab.coongyapay.charge.enums.TransactionType;
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
 import com.flab.coongyapay.common.exception.BusinessException;
 import com.flab.coongyapay.common.exception.ErrorCode;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionEntryMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionEntryMapperTest.java
@@ -1,0 +1,79 @@
+package com.flab.coongyapay.transaction.mapper;
+
+import com.flab.coongyapay.transaction.enums.TransactionEntryType;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionEntryDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@MybatisTest
+class TransactionEntryMapperTest {
+
+    @Autowired
+    private TransactionEntryMapper transactionEntryMapper;
+
+    @Test
+    void insert_성공하면_id_자동채번() {
+        TransactionEntryDto dto = getDto(1L, 1L);
+        transactionEntryMapper.insert(dto);
+
+        Assertions.assertThat(dto.getId()).isNotNull();
+    }
+
+    @Test
+    void findByTransactionIdAndEntryType_존재하면_반환() {
+        TransactionEntryDto dto = getDto(1L, 1L);
+        transactionEntryMapper.insert(dto);
+
+        Optional<TransactionEntryDto> found = transactionEntryMapper.findByTransactionIdAndEntryType(1L, TransactionEntryType.CREDIT.name());
+
+        Assertions.assertThat(found).isPresent();
+        Assertions.assertThat(found.get().getAmount()).isEqualByComparingTo(dto.getAmount());
+        Assertions.assertThat(found.get().getBalanceAfter()).isEqualByComparingTo(dto.getBalanceAfter());
+        Assertions.assertThat(found.get().getWalletSequence()).isEqualTo(dto.getWalletSequence());
+    }
+
+    @Test
+    void findByTransactionIdAndEntryType_없으면_empty() {
+        Optional<TransactionEntryDto> found = transactionEntryMapper.findByTransactionIdAndEntryType(999L, TransactionEntryType.CREDIT.name());
+
+        Assertions.assertThat(found).isEmpty();
+    }
+
+    @Test
+    void 동일_거래에_CREDIT_중복_기입되면_UNIQUE_위반() {
+        transactionEntryMapper.insert(getDto(1L, 1L));
+
+        // (transaction_id, entry_type) UNIQUE → 같은 거래의 두 번째 CREDIT은 차단 = 이중 입금 방지 백스톱
+        Assertions.assertThatThrownBy(() -> transactionEntryMapper.insert(getDto(1L, 1L)))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    void 동일_지갑_순번_중복이면_UNIQUE_위반() {
+        transactionEntryMapper.insert(getDto(1L, 1L));
+
+        // (wallet_id, wallet_sequence) UNIQUE → 같은 지갑의 같은 순번은 차단 = 순번 무결성
+        TransactionEntryDto sameSequence = getDto(2L, 1L); // 다른 거래, 같은 지갑/순번
+        Assertions.assertThatThrownBy(() -> transactionEntryMapper.insert(sameSequence))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    private TransactionEntryDto getDto(long transactionId, long walletSequence) {
+        return new TransactionEntryDto(
+                null,
+                transactionId,
+                1L,
+                TransactionEntryType.CREDIT.name(),
+                BigDecimal.valueOf(10_000),
+                BigDecimal.valueOf(10_000),
+                walletSequence,
+                null
+        );
+    }
+}

--- a/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
@@ -3,6 +3,8 @@ package com.flab.coongyapay.transaction.mapper;
 import com.flab.coongyapay.transaction.enums.TransactionStatus;
 import com.flab.coongyapay.transaction.enums.TransactionType;
 import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import com.flab.coongyapay.wallet.mapper.WalletMapper;
+import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -16,6 +18,8 @@ class TransactionMapperTest {
 
     @Autowired
     private TransactionMapper transactionMapper;
+    @Autowired
+    private WalletMapper walletMapper;
 
     @Test
     void insert_성공하면_id_자동채번() {
@@ -94,6 +98,52 @@ class TransactionMapperTest {
         BigDecimal sumInFlightChargeByWalletId = transactionMapper.sumInFlightChargeByWalletId(dto.getWalletId()+1);
 
         Assertions.assertThat(sumInFlightChargeByWalletId).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void findChargeByIdAndUserId_사용자의_충전거래_반환() {
+        WalletDto walletDto = new WalletDto(null, 1L, BigDecimal.ZERO, 0);
+        walletMapper.insert(walletDto);
+
+        TransactionDto dto = getDto();
+        dto.setWalletId(walletDto.getId());
+        transactionMapper.insert(dto);
+        Optional<TransactionDto> chargeByIdAndUserId = transactionMapper.findChargeByIdAndUserId(dto.getId(), 1L);
+
+        Assertions.assertThat(chargeByIdAndUserId).isPresent();
+        Assertions.assertThat(chargeByIdAndUserId.get().getWalletId()).isEqualTo(dto.getWalletId());
+        Assertions.assertThat(chargeByIdAndUserId.get().getTransactionType()).isEqualTo(dto.getTransactionType());
+        Assertions.assertThat(chargeByIdAndUserId.get().getAmount()).isEqualByComparingTo(dto.getAmount());
+        Assertions.assertThat(chargeByIdAndUserId.get().getStatus()).isEqualTo(dto.getStatus());
+        Assertions.assertThat(chargeByIdAndUserId.get().getRemark()).isEqualTo(dto.getRemark());
+        Assertions.assertThat(chargeByIdAndUserId.get().getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void findChargeByIdAndUserId_다른_사용자의_충전거래_반환_안_함() {
+        WalletDto walletDto = new WalletDto(null, 1L, BigDecimal.ZERO, 0);
+        walletMapper.insert(walletDto);
+
+        TransactionDto dto = getDto();
+        dto.setWalletId(walletDto.getId());
+        transactionMapper.insert(dto);
+        Optional<TransactionDto> otherUserTransaction = transactionMapper.findChargeByIdAndUserId(dto.getId(), 2L);
+
+        Assertions.assertThat(otherUserTransaction).isNotPresent();
+    }
+
+    @Test
+    void findChargeByIdAndUserId_충전거래_아니면_반환_안_함() {
+        WalletDto walletDto = new WalletDto(null, 1L, BigDecimal.ZERO, 0);
+        walletMapper.insert(walletDto);
+
+        TransactionDto dto = getDto();
+        dto.setWalletId(walletDto.getId());
+        dto.setTransactionType(TransactionType.WITHDRAW.toString());
+        transactionMapper.insert(dto);
+        Optional<TransactionDto> userWithdrawalTransaction = transactionMapper.findChargeByIdAndUserId(dto.getId(), 1L);
+
+        Assertions.assertThat(userWithdrawalTransaction).isNotPresent();
     }
 
     private static TransactionDto getDto() {

--- a/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
@@ -147,6 +147,6 @@ class TransactionMapperTest {
     }
 
     private static TransactionDto getDto() {
-        return new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        return new TransactionDto(null, 1L, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
     }
 }

--- a/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
@@ -1,0 +1,48 @@
+package com.flab.coongyapay.transaction.mapper;
+
+import com.flab.coongyapay.transaction.enums.TransactionStatus;
+import com.flab.coongyapay.transaction.enums.TransactionType;
+import com.flab.coongyapay.transaction.mapper.dto.TransactionDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@MybatisTest
+class TransactionMapperTest {
+
+    @Autowired
+    private TransactionMapper transactionMapper;
+
+    @Test
+    void insert_성공하면_id_자동채번() {
+        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        transactionMapper.insert(dto);
+        Assertions.assertThat(dto.getId()).isNotNull();
+    }
+
+    @Test
+    void findById_아이디_없으면_Optional_empty() {
+        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        transactionMapper.insert(dto);
+        Optional<TransactionDto> optional = transactionMapper.findById(dto.getId()+1);
+        Assertions.assertThat(optional).isEmpty();
+    }
+
+    @Test
+    void findById_아이디_있으면_row_반환() {
+        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        transactionMapper.insert(dto);
+        Optional<TransactionDto> optional = transactionMapper.findById(dto.getId());
+        Assertions.assertThat(optional).isPresent();
+        Assertions.assertThat(optional.get().getWalletId()).isEqualTo(dto.getWalletId());
+        Assertions.assertThat(optional.get().getTransactionType()).isEqualTo(dto.getTransactionType());
+        Assertions.assertThat(optional.get().getAmount()).isEqualByComparingTo(dto.getAmount());
+        Assertions.assertThat(optional.get().getStatus()).isEqualTo(dto.getStatus());
+        Assertions.assertThat(optional.get().getRemark()).isEqualTo(dto.getRemark());
+        Assertions.assertThat(optional.get().getCreatedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/transaction/mapper/TransactionMapperTest.java
@@ -19,14 +19,14 @@ class TransactionMapperTest {
 
     @Test
     void insert_성공하면_id_자동채번() {
-        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        TransactionDto dto = getDto();
         transactionMapper.insert(dto);
         Assertions.assertThat(dto.getId()).isNotNull();
     }
 
     @Test
     void findById_아이디_없으면_Optional_empty() {
-        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        TransactionDto dto = getDto();
         transactionMapper.insert(dto);
         Optional<TransactionDto> optional = transactionMapper.findById(dto.getId()+1);
         Assertions.assertThat(optional).isEmpty();
@@ -34,7 +34,7 @@ class TransactionMapperTest {
 
     @Test
     void findById_아이디_있으면_row_반환() {
-        TransactionDto dto = new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
+        TransactionDto dto = getDto();
         transactionMapper.insert(dto);
         Optional<TransactionDto> optional = transactionMapper.findById(dto.getId());
         Assertions.assertThat(optional).isPresent();
@@ -44,5 +44,59 @@ class TransactionMapperTest {
         Assertions.assertThat(optional.get().getStatus()).isEqualTo(dto.getStatus());
         Assertions.assertThat(optional.get().getRemark()).isEqualTo(dto.getRemark());
         Assertions.assertThat(optional.get().getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void sumInFlightChargeByWalletId_처리중_충전_금액_반환() {
+        TransactionDto createdDto = getDto();
+        createdDto.setAmount(new BigDecimal(10_000));
+        transactionMapper.insert(createdDto);
+
+        TransactionDto withdrawingDto = getDto();
+        withdrawingDto.setAmount(new BigDecimal(20_000));
+        withdrawingDto.setStatus(TransactionStatus.WITHDRAWING.toString());
+        transactionMapper.insert(withdrawingDto);
+
+        TransactionDto withdrawnDto = getDto();
+        withdrawnDto.setAmount(new BigDecimal(30_000));
+        withdrawnDto.setStatus(TransactionStatus.WITHDRAWN.toString());
+        transactionMapper.insert(withdrawnDto);
+
+        TransactionDto depositingDto = getDto();
+        depositingDto.setAmount(new BigDecimal(40_000));
+        depositingDto.setStatus(TransactionStatus.DEPOSITING.toString());
+        transactionMapper.insert(depositingDto);
+
+        TransactionDto unknownDto = getDto();
+        unknownDto.setAmount(new BigDecimal(50_000));
+        unknownDto.setStatus(TransactionStatus.UNKNOWN.toString());
+        transactionMapper.insert(unknownDto);
+
+        TransactionDto compensatingDto = getDto();
+        compensatingDto.setAmount(new BigDecimal(60_000));
+        compensatingDto.setStatus(TransactionStatus.COMPENSATING.toString());
+        transactionMapper.insert(compensatingDto);
+
+        TransactionDto completedDto = getDto();
+        completedDto.setAmount(new BigDecimal(70_000));
+        completedDto.setStatus(TransactionStatus.COMPLETED.toString());
+        transactionMapper.insert(completedDto);
+
+        BigDecimal sumInFlightChargeByWalletId = transactionMapper.sumInFlightChargeByWalletId(1L);
+
+        Assertions.assertThat(sumInFlightChargeByWalletId).isEqualByComparingTo(BigDecimal.valueOf(210_000));
+    }
+
+    @Test
+    void sumInFlightChargeByWalletId_행_없으면_0_반환() {
+        TransactionDto dto = getDto();
+        transactionMapper.insert(dto);
+        BigDecimal sumInFlightChargeByWalletId = transactionMapper.sumInFlightChargeByWalletId(dto.getWalletId()+1);
+
+        Assertions.assertThat(sumInFlightChargeByWalletId).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    private static TransactionDto getDto() {
+        return new TransactionDto(null, 1L, TransactionType.CHARGE.toString(), null, BigDecimal.ONE, TransactionStatus.CREATED.toString(), "김쿵야", null, null, null);
     }
 }

--- a/src/test/java/com/flab/coongyapay/user/domain/UserTransferPinTest.java
+++ b/src/test/java/com/flab/coongyapay/user/domain/UserTransferPinTest.java
@@ -1,0 +1,52 @@
+package com.flab.coongyapay.user.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+
+class UserTransferPinTest {
+
+    private static final String transferPinHash = "hash";
+
+    @Test
+    void increaseFailedTransferPinCount시_카운트_1_증가() {
+        UserTransferPin original = UserTransferPin.from(1L, 1L, transferPinHash, 0, null);
+
+        UserTransferPin incremented = original.incrementFailedTransferPinCount();
+
+        Assertions.assertThat(incremented.getFailedTransferPinCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 카운트_5회_도달시_잠김() {
+        UserTransferPin original = UserTransferPin.from(1L, 1L, transferPinHash, 4, null);
+
+        UserTransferPin incremented = original.incrementFailedTransferPinCount();
+
+        Assertions.assertThat(incremented.getFailedTransferPinCount()).isEqualTo(5);
+        Assertions.assertThat(incremented.isLockedAt(LocalDateTime.now())).isTrue();
+    }
+
+    @Test
+    void 카운트_4회까지는_잠금_없음() {
+        UserTransferPin original = UserTransferPin.from(1L, 1L, transferPinHash, 3, null);
+
+        UserTransferPin incremented = original.incrementFailedTransferPinCount();
+
+        Assertions.assertThat(incremented.getFailedTransferPinCount()).isEqualTo(4);
+        Assertions.assertThat(incremented.isLockedAt(LocalDateTime.now())).isFalse();
+    }
+
+    @Test
+    void resetFailedTransferPinCount시_카운트_및_잠금시각_리셋() {
+        UserTransferPin original = UserTransferPin.from(1L, 1L, transferPinHash, 5, UserTransferPin.PERMANENT_LOCK);
+
+        UserTransferPin reset = original.resetFailedTransferPinCount();
+
+        Assertions.assertThat(reset.getFailedTransferPinCount()).isZero();
+        Assertions.assertThat(reset.getLockedUntil()).isNull();
+        Assertions.assertThat(reset.isLockedAt(LocalDateTime.now())).isFalse();
+    }
+}

--- a/src/test/java/com/flab/coongyapay/user/service/UserTransferPinVerifierTest.java
+++ b/src/test/java/com/flab/coongyapay/user/service/UserTransferPinVerifierTest.java
@@ -1,0 +1,96 @@
+package com.flab.coongyapay.user.service;
+
+import com.flab.coongyapay.common.exception.BusinessException;
+import com.flab.coongyapay.common.exception.ErrorCode;
+import com.flab.coongyapay.user.domain.UserTransferPin;
+import com.flab.coongyapay.user.repository.UserTransferPinRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserTransferPinVerifierTest {
+
+    @InjectMocks
+    private UserTransferPinVerifier userTransferPinVerifier;
+
+    @Mock
+    private UserTransferPinRepository userTransferPinRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void 송금비밀번호_검증_성공시_실패카운트_잠금시각_리셋() {
+        when(userTransferPinRepository.findByUserIdForUpdate(1L))
+                .thenReturn(Optional.of(UserTransferPin.from(1L, 1L, "hash", 3, null)));
+        when(passwordEncoder.matches("111111", "hash")).thenReturn(true);
+
+        userTransferPinVerifier.verify(1L, "111111");
+
+        ArgumentCaptor<UserTransferPin> userTransferPinArgumentCaptor = ArgumentCaptor.forClass(UserTransferPin.class);
+        verify(userTransferPinRepository).update(userTransferPinArgumentCaptor.capture());
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().getFailedTransferPinCount()).isZero();
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().getLockedUntil()).isNull();
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().isLockedAt(LocalDateTime.now())).isFalse();
+    }
+
+    @Test
+    void 송금비밀번호_틀리면_INVALID_TRANSFER_PIN_던짐() {
+        when(userTransferPinRepository.findByUserIdForUpdate(1L))
+                .thenReturn(Optional.of(UserTransferPin.from(1L, 1L, "hash", 0, null)));
+        when(passwordEncoder.matches("111111", "hash")).thenReturn(false);
+
+        Assertions.assertThatThrownBy(() -> {
+                    userTransferPinVerifier.verify(1L, "111111");
+                }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRANSFER_PIN);
+
+        ArgumentCaptor<UserTransferPin> userTransferPinArgumentCaptor = ArgumentCaptor.forClass(UserTransferPin.class);
+        verify(userTransferPinRepository).update(userTransferPinArgumentCaptor.capture());
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().getFailedTransferPinCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 송금비밀번호_오류_5회_도달시_잠금_후_TRANSFER_PIN_LOCKED_던짐() {
+        when(userTransferPinRepository.findByUserIdForUpdate(1L))
+                .thenReturn(Optional.of(UserTransferPin.from(1L, 1L, "hash", 4, null)));
+        when(passwordEncoder.matches("111111", "hash")).thenReturn(false);
+
+        Assertions.assertThatThrownBy(() -> {
+                    userTransferPinVerifier.verify(1L, "111111");
+                }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TRANSFER_PIN_LOCKED);
+
+        ArgumentCaptor<UserTransferPin> userTransferPinArgumentCaptor = ArgumentCaptor.forClass(UserTransferPin.class);
+        verify(userTransferPinRepository).update(userTransferPinArgumentCaptor.capture());
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().getFailedTransferPinCount()).isEqualTo(5);
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().getLockedUntil()).isNotNull();
+        Assertions.assertThat(userTransferPinArgumentCaptor.getValue().isLockedAt(LocalDateTime.now())).isTrue();
+    }
+
+    @Test
+    void 송금비밀번호_잠겨있으면_TRANSFER_PIN_LOCKED_던짐() {
+        when(userTransferPinRepository.findByUserIdForUpdate(1L))
+                .thenReturn(Optional.of(UserTransferPin.from(1L, 1L, "hash", 5, UserTransferPin.PERMANENT_LOCK)));
+
+        Assertions.assertThatThrownBy(() -> {
+                    userTransferPinVerifier.verify(1L, "111111");
+                }).isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TRANSFER_PIN_LOCKED);
+
+        verify(passwordEncoder, never()).matches(any(), any());
+        verify(userTransferPinRepository, never()).update(any());
+    }
+
+}

--- a/src/test/java/com/flab/coongyapay/wallet/mapper/WalletMapperTest.java
+++ b/src/test/java/com/flab/coongyapay/wallet/mapper/WalletMapperTest.java
@@ -1,7 +1,6 @@
 package com.flab.coongyapay.wallet.mapper;
 
 import com.flab.coongyapay.user.mapper.UserMapper;
-import com.flab.coongyapay.user.mapper.dto.UserDto;
 import com.flab.coongyapay.wallet.mapper.dto.WalletDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,6 +8,7 @@ import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 @MybatisTest
 class WalletMapperTest {
@@ -20,11 +20,37 @@ class WalletMapperTest {
 
     @Test
     void insert_성공하면_id_자동채번() {
-        UserDto userDto = new UserDto(null, "user@example.com", "김쿵야");
-        userMapper.insert(userDto);
-
-        WalletDto walletDto = new WalletDto(null, userDto.getId(), BigDecimal.ZERO, 0);
+        WalletDto walletDto = getDto();
         walletMapper.insert(walletDto);
+
         Assertions.assertThat(walletDto.getId()).isNotNull();
+    }
+
+    @Test
+    void findByUserId_사용자_소유_지갑_반환() {
+        WalletDto walletDto = getDto();
+        walletMapper.insert(walletDto);
+        Optional<WalletDto> optional = walletMapper.findByUserId(walletDto.getUserId());
+
+        Assertions.assertThat(optional.isPresent()).isTrue();
+        Assertions.assertThat(optional.get().getUserId()).isEqualTo(walletDto.getUserId());
+        Assertions.assertThat(optional.get().getBalance()).isEqualByComparingTo(walletDto.getBalance());
+        Assertions.assertThat(optional.get().getVersion()).isEqualTo(walletDto.getVersion());
+    }
+
+    @Test
+    void findByUserIdForUpdate_사용자_소유_지갑_반환() {
+        WalletDto walletDto = getDto();
+        walletMapper.insert(walletDto);
+        Optional<WalletDto> optional = walletMapper.findByUserIdForUpdate(walletDto.getUserId());
+
+        Assertions.assertThat(optional.isPresent()).isTrue();
+        Assertions.assertThat(optional.get().getUserId()).isEqualTo(walletDto.getUserId());
+        Assertions.assertThat(optional.get().getBalance()).isEqualByComparingTo(walletDto.getBalance());
+        Assertions.assertThat(optional.get().getVersion()).isEqualTo(walletDto.getVersion());
+    }
+
+    private static WalletDto getDto() {
+        return new WalletDto(null, 1L, BigDecimal.ZERO, 0);
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -10,3 +10,8 @@ spring:
       continue-on-error: false
   session:
     store-type: none
+
+# 테스트는 스케줄 타이머 대신 ChargeProcessor.process()를 직접 호출한다.
+charge:
+  worker:
+    enabled: false


### PR DESCRIPTION
## 개요

이슈 #13 페이머니 충전 구현입니다. 동기 단계에서는 충전 거래 자격을 확인하고 요청 응답을 즉시 반환합니다. 동기 단계가 반환한 `202 CREATED` 이후, 워커가 상태머신을 끝까지 굴려 충전을 완료(또는 보상)시킵니다. 외부 은행 출금은 비가역이므로 전진 복구(크레딧 재시도) + 후진 복구(환불 보상) + 리컨실리에이션으로 정합성을 맞춥니다.

설계 원칙: 짧게 선점 → 락 밖에서 외부호출 → 짧게 기록. 
은행 호출은 트랜잭션/락 밖에서, 크레딧(원장)은 `wallet FOR UPDATE` 트랜잭션 안에서. 모든 상태 기록은 `lease_token` 펜싱으로 스테일 워커의 늦은 쓰기를 차단했습니다.

- 고민했던 부분: 페이머니 지갑 한도 검증시 사전 검증에서는 현재 잔액 + 충전 금액만 검증하여 빠른 실패로 처리했고, 실제 wallet 단위 락을 잡은 트랜잭션 내에서 현재 잔액뿐만 아니라 In-Flight 충전 금액까지 계산해서 검증하도록 했습니다.

## 단계별 요약

| 단계 | 내용 |
|---|---|
| **선행** | `transaction.account_id` 추가 — 워커가 출금 대상 계좌를 알 수 있도록 Part 1 접수 시 저장 (동기 단계에서 검증만 하고 저장하지 않던 잠재 결함 보완) |
| **3A** | 지갑 원장(`transaction_entry`) 레이어 신규 + 해피패스 크레딧. `wallet FOR UPDATE → CREDIT append → balance/version → COMPLETED`. **잔액이 실제로 증가.** `UNIQUE(transaction_id, entry_type)`로 이중 입금 차단 |
| **3B** | 워커 내구성: `FOR UPDATE SKIP LOCKED` 선점 + `lease_token` **펜싱**. `@Scheduled` 내구 워커 + 커밋 후 `@Async` fast-path |
| **3C** | 실패/불명 분류: 4xx→`FAILED(WITHDRAWAL_REJECTED)`, timeout/5xx→`UNKNOWN`. UNKNOWN 대사(재조회·freshness·상한→`NEEDS_REVIEW`), 실행시점 점검시간 재확인, 크레딧 transient 백오프 재시도 |
| **3D** | 후진복구(보상 사가): 크레딧 영구실패→`COMPENSATING`+보상거래 생성(`UNIQUE(parent_transaction_id)`). 상태머신 B로 환불→`COMPLETED`→부모 `FAILED(REFUNDED)` |
| **3E** | 리컨실리에이션: 유휴 `CREATED`→`EXPIRED`, 내부 3-테이블 불변식 검증(balance/version/CREDIT 무결성), 수렴 정체 모니터링 지표 |

## 다층 멱등성·동시성

- Client ↔ API: 멱등키 claim `(user_id, endpoint, key)`
- Worker ↔ Reconciliation: CAS(상태) + `lease_token` fencing
- 페이 시스템 ↔ 외부 은행: 외부 멱등키 `external_idempotency_key`
- 크레딧 재실행: 원장 `UNIQUE(transaction_id, entry_type)`
- 보상 중복: `UNIQUE(parent_transaction_id)`

## 테스트

- **원장/매퍼**(`@MybatisTest`, Testcontainers): 이중 입금·순번 UNIQUE, 대사 불변식(델타 검증)
- **워커 통합**(`@SpringBootTest`): 선점→처리 **잔액 증가**, 이중처리 멱등, **스테일 leaseToken 펜싱 차단**
- **실패 시나리오**: 거절→FAILED, 불명→UNKNOWN, 대사 확인→완료, 미출금 재출금, 재조회 상한→NEEDS_REVIEW, 점검시간→FAILED
- **보상 사가**(다중 tx 비트랜잭션): 한도초과→보상→환불→부모 FAILED(REFUNDED), 잔액 불변·CREDIT 없음

전체 `./gradlew test` GREEN.

## 범위 밖(후속)

실제 은행 연동(현 Stub), FDS(이상거래탐지), 다중 인스턴스 스케줄러 조정(ShedLock 등).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
